### PR TITLE
feat: add Claude Code compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # detritus
 
-MCP knowledge base server. Exposes coding knowledge as MCP tools for AI assistants across VS Code, Windsurf, Cursor, and Verdent.
+MCP knowledge base server. Exposes coding knowledge as MCP tools for AI assistants across VS Code, Windsurf, Cursor, Claude Code, and Verdent.
 
 ## Install
 

--- a/main.go
+++ b/main.go
@@ -276,7 +276,7 @@ func aliasForDoc(name string) string {
 // and writes it back. Creates the file if it doesn't exist.
 func upsertMCP(file, parentKey, command string) {
 	data := map[string]any{}
-	if raw, err := os.ReadFile(file); err == nil {
+	if raw, err := os.ReadFile(file); err == nil && len(raw) > 0 {
 		if err := json.Unmarshal(raw, &data); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to parse %s: %v\n", file, err)
 			os.Exit(1)

--- a/setup.go
+++ b/setup.go
@@ -67,6 +67,9 @@ func RunSetup(binaryPath string, dryRun bool) error {
 	// Cursor
 	setupCursor(home, binaryPath, dryRun)
 
+	// Claude Code
+	setupClaudeCode(home, binaryPath, dryRun)
+
 	// Verdent
 	if verdentDetected(home) {
 		setupVerdent(home, binaryPath, docs, dryRun)
@@ -291,6 +294,22 @@ func setupCursor(home, binaryPath string, dryRun bool) {
 	}
 }
 
+// ---- Claude Code -------------------------------------------------------------
+
+func setupClaudeCode(home, binaryPath string, dryRun bool) {
+	cfgFile := filepath.Join(home, ".claude", "mcp.json")
+	if dryRun {
+		fmt.Printf("[dry-run] Would upsert detritus into %s (mcpServers)\n", cfgFile)
+		return
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgFile), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: claude config dir: %v\n", err)
+		return
+	}
+	upsertMCP(cfgFile, "mcpServers", binaryPath)
+	fmt.Printf("Claude Code MCP config: %s\n", cfgFile)
+}
+
 // ---- Verdent ----------------------------------------------------------------
 
 func verdentDetected(home string) bool {
@@ -484,6 +503,14 @@ func printVerification(home string) {
 		} else {
 			fmt.Println("  [WARN] Verdent skills")
 		}
+	}
+
+	// Claude Code
+	claudeFile := filepath.Join(home, ".claude", "mcp.json")
+	if fileContains(claudeFile, `"detritus"`) {
+		fmt.Println("  [PASS] Claude Code MCP entry")
+	} else {
+		fmt.Println("  [WARN] Claude Code MCP entry not found")
 	}
 }
 


### PR DESCRIPTION
Add support for Claude Code as an MCP client alongside existing IDEs. Claude Code users can now access the detritus knowledge base.

Changes:
- setup.go: Add setupClaudeCode() function to configure ~/.claude/mcp.json
- setup.go: Include Claude Code in RunSetup() and verification
- main.go: Fix upsertMCP() to handle empty JSON files gracefully
- README.md: Update description to include Claude Code

The MCP server now supports: VS Code, Windsurf, Cursor, Claude Code, and Verdent.