### PR TITLE
fix(update): exec new binary's --setup so new skills are installed

### DIFF
--- a/update.go
+++ b/update.go
@@ -9,8 +9,10 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"time"
 )
 
@@ -60,7 +62,23 @@ func RunUpdate(currentBinary string, dryRun bool) error {
 
 	fmt.Printf("Updated to %s\n", latest)
 	fmt.Println("Running --setup...")
-	return RunSetup(currentBinary, false)
+	// Exec the NEW binary so --setup uses the new embedded docs
+	// (the running process still holds the old binary's docsFS in memory).
+	return execNewBinarySetup(currentBinary)
+}
+
+// execNewBinarySetup runs `<binary> --setup` using the new binary on disk.
+// On Unix it replaces the current process via syscall.Exec so the user sees
+// the new binary's output directly. On Windows it spawns a child and exits.
+func execNewBinarySetup(binary string) error {
+	if runtime.GOOS == "windows" {
+		cmd := exec.Command(binary, "--setup")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+		return cmd.Run()
+	}
+	return syscall.Exec(binary, []string{binary, "--setup"}, os.Environ())
 }
 
 type githubRelease struct {


### PR DESCRIPTION
RunUpdate previously called the in-process RunSetup after replacing the binary on disk. RunSetup uses the embedded docsFS, which is baked into the *currently executing* binary — i.e. the OLD code still in memory. Skills added in the new release wouldn't appear until the user ran `detritus --setup` manually.

Now RunUpdate exec's the new binary's --setup so the skill set comes from the new embedded docs. Unix uses syscall.Exec to replace the process; Windows spawns a child and waits.