### PR TITLE
chore(release): sync plugin metadata to v3.10.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.0.0",
+  "version": "3.10.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "detritus",
-    "version": "3.0.0",
+    "version": "3.10.0",
     "description": "Knowledge base plugin for the ooo ecosystem — coding patterns, testing workflows, and library documentation served via MCP tools and agent skills",
     "author": "benitogf",
     "repository": "https://github.com/benitogf/detritus"


### PR DESCRIPTION
## Summary
Keeps the default-branch plugin metadata aligned with the latest published release.

- Updates the Codex plugin metadata version to v3.10.0.
- Updates the legacy plugin metadata version to v3.10.0.

## Test plan
- [ ] Confirm the latest release is v3.10.0.
- [ ] Confirm plugin metadata on the default branch reports v3.10.0 after merge.

---
Generated with [Claude Code](https://claude.com/claude-code)