### PR TITLE
fix(codex): use conventional plugin marketplace layout

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -8,7 +8,7 @@
       "name": "detritus",
       "source": {
         "source": "local",
-        "path": "."
+        "path": "./plugins/detritus"
       },
       "policy": {
         "installation": "AVAILABLE",

--- a/plugins/detritus/.codex-plugin/plugin.json
+++ b/plugins/detritus/.codex-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "detritus",
+  "version": "3.10.0",
+  "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
+  "author": {
+    "name": "benitogf",
+    "url": "https://github.com/benitogf"
+  },
+  "homepage": "https://github.com/benitogf/detritus#readme",
+  "repository": "https://github.com/benitogf/detritus",
+  "license": "MIT",
+  "keywords": [
+    "mcp",
+    "knowledge-base",
+    "coding-patterns",
+    "testing",
+    "go"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "Detritus",
+    "shortDescription": "Coding knowledge base served over MCP",
+    "longDescription": "Detritus exposes a local knowledge base of software engineering patterns, testing workflows, Go guidance, and ooo ecosystem documentation through MCP tools for Codex.",
+    "developerName": "benitogf",
+    "category": "Engineering",
+    "capabilities": [
+      "Read"
+    ],
+    "websiteURL": "https://github.com/benitogf/detritus",
+    "defaultPrompt": [
+      "Search detritus for testing guidance",
+      "Use detritus to plan this change",
+      "Find the Go style guidance"
+    ],
+    "brandColor": "#305C7A",
+    "screenshots": []
+  }
+}

--- a/plugins/detritus/.mcp.json
+++ b/plugins/detritus/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "detritus": {
+      "command": "node",
+      "args": [
+        "../../scripts/detritus-mcp.js"
+      ]
+    }
+  }
+}

--- a/plugins/detritus/commands/coding-style.md
+++ b/plugins/detritus/commands/coding-style.md
@@ -1,0 +1,10 @@
+---
+description: Use detritus coding style guidance for naming, errors, and commits
+argument-hint: [code-or-question]
+---
+
+# Coding Style
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="patterns/coding-style"` and apply the returned coding-style guidance to the user's code or question.

--- a/plugins/detritus/commands/go-modern.md
+++ b/plugins/detritus/commands/go-modern.md
@@ -1,0 +1,10 @@
+---
+description: Use detritus guidance for modern Go idioms
+argument-hint: [go-code-or-question]
+---
+
+# Modern Go
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="patterns/go-modern"` and apply the returned modern Go guidance to the user's code or question.

--- a/plugins/detritus/commands/grow.md
+++ b/plugins/detritus/commands/grow.md
@@ -1,0 +1,10 @@
+---
+description: Improve the detritus knowledge base from corrections and observed gaps
+argument-hint: [correction-or-gap]
+---
+
+# Grow Detritus
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="meta/grow"` and follow the returned guidance for turning the correction or gap into a knowledge-base improvement.

--- a/plugins/detritus/commands/line-of-sight.md
+++ b/plugins/detritus/commands/line-of-sight.md
@@ -1,0 +1,10 @@
+---
+description: Use detritus line-of-sight guidance for flat, readable code
+argument-hint: [code-or-refactor]
+---
+
+# Line Of Sight
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="patterns/line-of-sight"` and apply the returned guidance for flat, readable control flow.

--- a/plugins/detritus/commands/optimize.md
+++ b/plugins/detritus/commands/optimize.md
@@ -1,0 +1,10 @@
+---
+description: Optimize detritus knowledge retrieval and document findability
+argument-hint: [retrieval-problem]
+---
+
+# Optimize Detritus
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="meta/optimize"` and follow the returned guidance for improving retrieval quality.

--- a/plugins/detritus/commands/plan.md
+++ b/plugins/detritus/commands/plan.md
@@ -1,0 +1,10 @@
+---
+description: Use detritus planning guidance for requirements analysis and implementation planning
+argument-hint: [task-or-feature]
+---
+
+# Plan With Detritus
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="plan/index"` and follow the returned planning guidance for the user's task.

--- a/plugins/detritus/commands/testing.md
+++ b/plugins/detritus/commands/testing.md
@@ -1,0 +1,10 @@
+---
+description: Use detritus testing guidance and decision tables
+argument-hint: [feature-or-risk]
+---
+
+# Testing With Detritus
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="testing/index"` and follow the returned testing guidance for the user's task.

--- a/plugins/detritus/commands/truthseeker.md
+++ b/plugins/detritus/commands/truthseeker.md
@@ -1,0 +1,10 @@
+---
+description: Use detritus evidence-based reasoning guardrails
+argument-hint: [question-or-claim]
+---
+
+# Truthseeker
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="meta/truthseeker"` and apply the returned evidence-based reasoning guardrails to the user's question or claim.

--- a/plugins/detritus/skills/detritus/SKILL.md
+++ b/plugins/detritus/skills/detritus/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: detritus
+description: Use the detritus MCP knowledge base for software-engineering guidance, including planning, testing workflows, Go idioms, coding patterns, and ooo ecosystem documentation.
+---
+
+# Detritus
+
+Use the detritus MCP server as the first stop for questions about this knowledge base: planning, testing strategy, Go backend patterns, state management, line-of-sight code, coding style, ooo ecosystem docs, and repository knowledge packs.
+
+## Workflow
+
+1. Use `kb_search` when the right document is unclear.
+2. Use `kb_get` when a document name is known or a search result identifies the right document.
+3. Use `kb_sections` before fetching a narrow section from a long document.
+4. Ground the answer in the returned detritus content, then apply it to the user's current code or question.
+
+## Common Documents
+
+- `plan/index` for implementation planning.
+- `testing/index` for testing strategy.
+- `patterns/coding-style` for coding conventions.
+- `patterns/go-modern` for modern Go idioms.
+- `patterns/line-of-sight` for flat, readable control flow.
+- `ooo/package` for ooo package guidance.


### PR DESCRIPTION
## Summary
Moves the Codex plugin components into the conventional marketplace plugin layout so Codex can discover the commands and skill when the detritus marketplace is installed.

- Points the marketplace entry at the detritus plugin directory.
- Adds the Codex manifest, MCP config, slash commands, and skill under that plugin directory.
- Keeps the MCP launcher wired to the existing release-binary downloader.

## Test plan
- [ ] Install or upgrade the detritus marketplace in Codex.
- [ ] Restart Codex and confirm detritus commands appear in the slash command menu.
- [ ] Invoke a detritus command and confirm the MCP server starts.

---
Generated with [Claude Code](https://claude.com/claude-code)