### PR TITLE
chore(codex): bump plugin to v3.12.0

### DIFF
--- a/plugins/detritus/.codex-plugin/plugin.json
+++ b/plugins/detritus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",


### PR DESCRIPTION
## Summary
- Bumps the Codex plugin manifest version to 3.12.0 so Codex can pick up the merged setup changes under a new plugin cache version.

## Test plan
- [x] go test .

## Release note
After this merges, tag v3.12.0 from main and let GoReleaser publish the binary release.