### PR TITLE
chore: sync v3.12.0 plugin metadata

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "detritus",
-    "version": "3.11.0",
+    "version": "3.12.0",
     "description": "Knowledge base plugin for the ooo ecosystem — coding patterns, testing workflows, and library documentation served via MCP tools and agent skills",
     "author": "benitogf",
     "repository": "https://github.com/benitogf/detritus"


### PR DESCRIPTION
## Summary
- Syncs the root plugin metadata copies to 3.12.0 after the marketplace plugin manifest bump.

## Test plan
- [x] go test .