### PR TITLE
fix(setup): robust Copilot slash-command routing for /janitor

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ var version = "dev"
 //go:embed docs
 var docsFS embed.FS
 
+//go:embed commands
+var commandsFS embed.FS
+
 //go:embed generated/data.gob
 var dataFS embed.FS
 

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -287,4 +288,38 @@ func TestListFlag(t *testing.T) {
 
 func contains(s, substr string) bool {
 	return len(s) > 0 && len(substr) > 0 && strings.Contains(s, substr)
+}
+
+func TestListCommandAliasesIncludesJanitor(t *testing.T) {
+	aliases := listCommandAliases()
+	if !aliases["janitor"] {
+		t.Fatal("expected janitor alias in command shim list")
+	}
+	if !aliases["truthseeker"] {
+		t.Fatal("expected truthseeker alias in command shim list")
+	}
+}
+
+func TestGenerateInlineCommandInstructionsUsesCommandOnlyMap(t *testing.T) {
+	home := t.TempDir()
+	docs := listDocEntries()
+
+	generateInlineCommandInstructions(home, docs, false)
+
+	path := filepath.Join(home, ".copilot", "instructions", "detritus.instructions.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read generated instructions: %v", err)
+	}
+	text := string(data)
+
+	if !strings.Contains(text, "- /janitor -> meta/janitor") {
+		t.Fatal("expected /janitor mapping in generated instructions")
+	}
+	if strings.Contains(text, "- /loop-core -> meta/loop-core") {
+		t.Fatal("unexpected /loop-core mapping; non-command docs should not appear")
+	}
+	if !strings.Contains(text, "If a slash command token appears but is not in the mapping") {
+		t.Fatal("expected unmapped slash fallback rule")
+	}
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "detritus",
-    "version": "3.14.0",
+    "version": "3.14.1",
     "description": "Knowledge base plugin for the ooo ecosystem — coding patterns, testing workflows, and library documentation served via MCP tools and agent skills",
     "author": "benitogf",
     "repository": "https://github.com/benitogf/detritus"

--- a/plugins/detritus/.codex-plugin/plugin.json
+++ b/plugins/detritus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/setup.go
+++ b/setup.go
@@ -198,13 +198,35 @@ func generateInlineCommandInstructions(home string, docs []docEntry, dryRun bool
 	sb.WriteString("2. Support multiple tokens in one message; process all of them (deduplicated) in order of appearance.\n")
 	sb.WriteString("3. For each detected token, call kb_get(name=\"...\") with the mapped doc name before producing the final answer.\n")
 	sb.WriteString("4. If no token is present, do not force a kb_get call from this instruction alone.\n\n")
+	sb.WriteString("5. If a slash command token appears but is not in the mapping, call kb_search(query=\"<token-without-slash>\") and then kb_get the best match before answering.\n\n")
 	sb.WriteString("Token to doc mapping:\n")
+	commandAliases := listCommandAliases()
 	for _, doc := range docs {
+		if !commandAliases[doc.alias] {
+			continue
+		}
 		fmt.Fprintf(&sb, "- /%s -> %s\n", doc.alias, doc.name)
 	}
 
 	_ = os.WriteFile(instrFile, []byte(sb.String()), 0o644)
 	fmt.Printf("VS Code shared instructions: %s\n", instrFile)
+}
+
+// listCommandAliases returns slash-command aliases by reading embedded
+// command shim filenames under commands/*.md.
+func listCommandAliases() map[string]bool {
+	out := map[string]bool{}
+	_ = fs.WalkDir(commandsFS, "commands", func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(path, ".md") {
+			return nil
+		}
+		base := strings.TrimSuffix(filepath.Base(path), ".md")
+		if base != "" {
+			out[base] = true
+		}
+		return nil
+	})
+	return out
 }
 
 func generateAgentFile(home string, dryRun bool) {


### PR DESCRIPTION
## Summary
- Generate Copilot token mapping from command shims only (minimal per-platform fingerprint)
- Add unknown slash-token fallback rule (kb_search -> kb_get)
- Add regression tests to prevent missing /janitor mapping
- Bump plugin manifests to 3.14.1

## Validation
- go test ./... (pass)
- setup regeneration verified includes /janitor and fallback rule

After merge, tag for release.