### PR TITLE
feat(meta): self-review loops until clean and runs after feedback work

### DIFF
--- a/docs/meta/gh-feedback-work.md
+++ b/docs/meta/gh-feedback-work.md
@@ -11,6 +11,7 @@ when: User invokes /gh-feedback-work on a PR with outstanding review comments or
 related:
   - meta/gh-issue-create
   - meta/gh-issue-work
+  - meta/gh-self-review
 ---
 
 # /gh-feedback-work — Address PR Feedback, Update PR Body In Place
@@ -38,7 +39,7 @@ This applies to PR bodies, issue bodies, comment bodies, release notes. It does 
 
 ## Phase 0: Track progress
 
-Initialize a `TodoWrite` list mirroring phases 1–6 so the user can see where the flow is at a glance. Update in real time — mark in-progress before starting each phase, completed immediately after.
+Initialize a `TodoWrite` list mirroring phases 1–7 so the user can see where the flow is at a glance. Update in real time — mark in-progress before starting each phase, completed immediately after.
 
 ## Phase 1: Collect feedback
 
@@ -91,7 +92,21 @@ Commit convention:
 - Conventional-commits message (`fix(<scope>): …`, `refactor(<scope>): …`).
 - `Co-Authored-By: Claude …` footer in every commit.
 
-## Phase 4: Push
+## Phase 4: Self-review the fixes before pushing
+
+Invoke `/gh-self-review` against the working tree (committed scope). Follow its loop-until-clean semantics — fresh sub-agent per iteration, rigor checklist, up to 3 iterations or until the triage is empty.
+
+**Why this phase exists**: addressing review feedback can introduce regressions in code paths the feedback's tests don't exercise. The reviewer caught the original issue; their tests covered that. Your fix's tests cover the fix. Neither catches "did this fix break adjacent behavior?". A fresh sub-agent reading the post-fix diff catches that locally — saves a reviewer round-trip and avoids compounding regressions across review rounds.
+
+If `/gh-self-review` surfaces blockers:
+
+- Return to Phase 3, address them, commit. Don't amend prior commits — they're already part of the feedback-fix story, additional commits are fine.
+- Re-run `/gh-self-review`. Same loop bound (3 iterations) applies to the combined flow, not just to the inner skill.
+- Push (Phase 5) only after `/gh-self-review` returns clean OR the dev explicitly accepts remaining items.
+
+**Composition**: this phase delegates entirely to `/gh-self-review` — do not re-implement scope detection, sub-agent spawning, or the rigor checklist here. The wrapping skill's job is to insert the call at the right point in the feedback-work flow; the review work itself lives in its own skill.
+
+## Phase 5: Push
 
 ```
 git push
@@ -99,7 +114,7 @@ git push
 
 The branch is already tracking upstream from `gh pr checkout`; no `-u` needed.
 
-## Phase 5: Rewrite PR body in place (not via comments)
+## Phase 6: Rewrite PR body in place (not via comments)
 
 Fetch the current body:
 ```
@@ -128,7 +143,7 @@ gh api --method PATCH repos/<owner>/<repo>/pulls/<pr> \
   --jq .html_url
 ```
 
-## Phase 6: Report back
+## Phase 7: Report back
 
 Print, in the terminal (not to GitHub):
 - PR URL on its own line.

--- a/docs/meta/gh-feedback-work.md
+++ b/docs/meta/gh-feedback-work.md
@@ -94,15 +94,16 @@ Commit convention:
 
 ## Phase 4: Self-review the fixes before pushing
 
-Invoke `/gh-self-review` **once** against the working tree (committed scope). The inner skill owns the loop: it spawns a fresh sub-agent per iteration, applies the rigor checklist, and exits on its own stop conditions (empty triage, all remaining items deferred by the dev, or 3 iterations exhausted).
+Invoke `/gh-self-review` **once** against the post-fix tree. The inner skill detects its own scope — normally committed-only at this point (Phase 3 commits each addressed item), but if uncommitted or untracked files remain it will surface them. The inner skill owns the loop: it spawns a fresh sub-agent per iteration (the dev addresses items between iterations; the skill re-audits), applies the rigor checklist, and exits on its own stop conditions (empty triage, all remaining items deferred by the dev, or 3 iterations exhausted).
 
 **Why this phase exists**: addressing review feedback can introduce regressions in code paths the feedback's tests don't exercise. The reviewer caught the original issue; their tests covered that. Your fix's tests cover the fix. Neither catches "did this fix break adjacent behavior?". A fresh sub-agent reading the post-fix diff catches that locally — saves a reviewer round-trip and avoids compounding regressions across review rounds.
 
-When `/gh-self-review` returns:
+**Push is gated on a clean exit from `/gh-self-review`.** Concretely:
 
 - **Triage empty** → proceed to Phase 5.
-- **Blockers fixed inside the loop** → /gh-self-review already drove fix-and-re-audit until clean; proceed to Phase 5.
-- **Surviving items after 3 iterations** → /gh-self-review surfaces these to the dev per its own accept / defer / escalate exit. Resolve there. Proceed to Phase 5 only after the dev explicitly accepts the remaining items (folded into the PR body's "Known non-blockers" section per Phase 6) or escalates.
+- **Blockers addressed across iterations** → the dev fixed items between fresh-sub-agent passes; the inner skill re-audited until clean. Proceed to Phase 5.
+- **Surviving items after 3 iterations** → the inner skill surfaces these per its own accept / defer / escalate exit. Resolve there. Proceed to Phase 5 only after the dev explicitly accepts the remaining items (folded into the PR body's "Known non-blockers" section per Phase 6) or escalates.
+- **None of the above** → do not push. Return to Phase 3.
 
 This skill does NOT wrap `/gh-self-review` in a second outer loop — that would push past the inner cap and duplicate logic the inner skill already owns. Cap ownership lives in `/gh-self-review`; this phase is a single delegated call.
 

--- a/docs/meta/gh-feedback-work.md
+++ b/docs/meta/gh-feedback-work.md
@@ -72,7 +72,7 @@ For each post-last-commit feedback item, pick exactly one label:
 | Label | Meaning | Action |
 |---|---|---|
 | **actionable** | asks for a concrete code change | implement in Phase 3 |
-| **in-body** | question answerable by clarifying the PR body | answer in Phase 5 rewrite |
+| **in-body** | question answerable by clarifying the PR body | answer in Phase 6 rewrite |
 | **out-of-scope** | valid but belongs in a separate issue/PR | capture as a follow-up; offer to run `/gh-issue-create` afterwards |
 
 Present the classification to the user. If more than 2 items are **actionable**, WAIT for confirmation before touching code.
@@ -94,17 +94,19 @@ Commit convention:
 
 ## Phase 4: Self-review the fixes before pushing
 
-Invoke `/gh-self-review` against the working tree (committed scope). Follow its loop-until-clean semantics — fresh sub-agent per iteration, rigor checklist, up to 3 iterations or until the triage is empty.
+Invoke `/gh-self-review` **once** against the working tree (committed scope). The inner skill owns the loop: it spawns a fresh sub-agent per iteration, applies the rigor checklist, and exits on its own stop conditions (empty triage, all remaining items deferred by the dev, or 3 iterations exhausted).
 
 **Why this phase exists**: addressing review feedback can introduce regressions in code paths the feedback's tests don't exercise. The reviewer caught the original issue; their tests covered that. Your fix's tests cover the fix. Neither catches "did this fix break adjacent behavior?". A fresh sub-agent reading the post-fix diff catches that locally — saves a reviewer round-trip and avoids compounding regressions across review rounds.
 
-If `/gh-self-review` surfaces blockers:
+When `/gh-self-review` returns:
 
-- Return to Phase 3, address them, commit. Don't amend prior commits — they're already part of the feedback-fix story, additional commits are fine.
-- Re-run `/gh-self-review`. Same loop bound (3 iterations) applies to the combined flow, not just to the inner skill.
-- Push (Phase 5) only after `/gh-self-review` returns clean OR the dev explicitly accepts remaining items.
+- **Triage empty** → proceed to Phase 5.
+- **Blockers fixed inside the loop** → /gh-self-review already drove fix-and-re-audit until clean; proceed to Phase 5.
+- **Surviving items after 3 iterations** → /gh-self-review surfaces these to the dev per its own accept / defer / escalate exit. Resolve there. Proceed to Phase 5 only after the dev explicitly accepts the remaining items (folded into the PR body's "Known non-blockers" section per Phase 6) or escalates.
 
-**Composition**: this phase delegates entirely to `/gh-self-review` — do not re-implement scope detection, sub-agent spawning, or the rigor checklist here. The wrapping skill's job is to insert the call at the right point in the feedback-work flow; the review work itself lives in its own skill.
+This skill does NOT wrap `/gh-self-review` in a second outer loop — that would push past the inner cap and duplicate logic the inner skill already owns. Cap ownership lives in `/gh-self-review`; this phase is a single delegated call.
+
+**Composition**: this phase delegates entirely to `/gh-self-review` — do not re-implement scope detection, sub-agent spawning, the rigor checklist, or the iteration cap here. The wrapping skill's job is to insert the call at the right point in the feedback-work flow; the review work itself lives in its own skill.
 
 ## Phase 5: Push
 

--- a/docs/meta/gh-self-review.md
+++ b/docs/meta/gh-self-review.md
@@ -162,6 +162,8 @@ Stop conditions:
 
 Each iteration spawns a NEW `Agent` invocation — never reuse the prior sub-agent. The freshness contract (Phase 3) holds per-iteration; a carried-over agent would re-inherit its own prior reasoning and the loop loses its independence.
 
+**Iteration 2+ scope handling.** Phase 1 re-runs to pick up new commits the dev made between iterations — committed scope evolves naturally. Only re-prompt the dev about modified/untracked files if the set *changed* since the prior iteration (new untracked files appeared, or files in the prior in-scope set are no longer in the working tree). If the modified/untracked set is unchanged, carry the prior iteration's in-scope decision forward silently — don't re-ask the same question.
+
 ## Why hand off to a fresh agent
 
 Self-review by the author who wrote the change shares the author's blind spots — the same mental model that produced the bug fails to catch it. The conversation that led to the diff also carries justifications ("we agreed this was fine") that bias the audit toward acceptance. Delegating to a fresh sub-agent:

--- a/docs/meta/gh-self-review.md
+++ b/docs/meta/gh-self-review.md
@@ -150,6 +150,18 @@ The sub-agent returns the triage block. Don't re-edit it; the freshness is the p
 
 If the sub-agent returned with empty sections only ("nothing to flag"), report that — don't manufacture findings to fill space.
 
+## Phase 5: Loop until clean
+
+A single sub-agent pass can miss regressions a fix introduces. Fixing one blocker often perturbs adjacent code in ways the first review didn't flag — the canonical failure shape this loop exists to catch. After the dev addresses items from Phase 4, **re-run Phases 1–4 against the updated tree** with a fresh sub-agent (no carry-over context — each iteration is independent).
+
+Stop conditions:
+
+- Sub-agent's triage is empty.
+- All remaining items are non-blockers the dev explicitly defers — fold those into the PR body's "Known non-blockers" section.
+- Loop has run 3 iterations. A finding that survives three independent fresh-sub-agent passes is unlikely to be phantom; surface the persistence to the dev for accept / defer / escalate.
+
+Each iteration spawns a NEW `Agent` invocation — never reuse the prior sub-agent. The freshness contract (Phase 3) holds per-iteration; a carried-over agent would re-inherit its own prior reasoning and the loop loses its independence.
+
 ## Why hand off to a fresh agent
 
 Self-review by the author who wrote the change shares the author's blind spots — the same mental model that produced the bug fails to catch it. The conversation that led to the diff also carries justifications ("we agreed this was fine") that bias the audit toward acceptance. Delegating to a fresh sub-agent:

--- a/docs/meta/grow.md
+++ b/docs/meta/grow.md
@@ -63,6 +63,7 @@ Scan the current conversation for these signal types:
 | **explicit_correction** | user says "no", "that's wrong", "don't do that", "stop", "I said", "not like that" |
 | **missed_existing** | user points to existing doc/workflow/rule that agent should have used: "already exists", "check the docs", "use /X", "kb_get" |
 | **rule_violation** | agent action contradicts established KB guidance (e.g., used sleep in tests, added backwards compat, skipped WaitGroup) |
+| **skill_invocation_ignored** | user typed `/<name>` in the triggering message — or in any user message earlier in the turn — but the agent did not invoke that skill. The base-prompt rule is unambiguous ("When users reference a slash command or /<something>, they are referring to a skill. Use this tool to invoke it"), but mid-prose mentions like "referencing /X /Y" or "see /X for the pattern" are easy to read as references-to-look-at instead of invoke-now. Default per the base prompt is INVOKE; reading-as-reference requires explicit "don't run X, just look at it" framing from the user. During Step 1 extraction, list every `/<name>` the user typed and verify a matching `Skill` tool call appears in the same turn. |
 | **implicit_redirect** | user silently fixes something agent did wrong (e.g., provides corrected code, rewrites a section) |
 | **scope_drift** | agent changed requirements without approval, added unrequested features, or deviated from the task |
 | **quality_bar** | user raises or clarifies quality expectations ("these docs are for you not humans", "optimize for retrieval") |


### PR DESCRIPTION
## Summary
Closes #33 — self-review now runs as a loop instead of a single pass, and the address-PR-feedback flow runs self-review between fixes and push. The `/grow` signal-extraction step gains a row for the skill-invocation-ignored failure mode the same session surfaced.

- A pass through self-review that surfaces blockers no longer stops there. After the dev addresses items, the same flow re-runs with a fresh sub-agent until the triage is empty, the dev explicitly defers remaining items, or three iterations have completed.
- Address-PR-feedback gains a new step between addressing fixes and pushing: invoke self-review and gate the push on a clean exit (triage empty, or all surviving items explicitly accepted by the dev). Composes the existing self-review skill by reference — no rigor checklist, sub-agent logic, or iteration cap duplicated in the wrapping flow.
- `/grow`'s Step 1 signal table picks up a `skill_invocation_ignored` row so future correction-extraction runs flag the case where a user typed `/<name>` in their message but the agent did not invoke that skill in the same turn.

## Test plan
- [ ] Invoke `/gh-self-review` on a diff with an intentional regression — sub-agent flags it, dev fixes it, the loop re-runs with a fresh sub-agent until the triage clears.
- [ ] Invoke `/gh-feedback-work` on a PR with outstanding review comments — verify the new self-review step runs after the fixes and that push is held until the triage is clean or explicit acceptance is given.
- [ ] Invoke `/grow` in a session where a user typed a slash command the agent didn't run — the new signal-extraction row catches it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)