### PR TITLE
docs(meta): require markdown-link form for cross-repo refs in gh-* bodies

### DIFF
--- a/docs/meta/gh-feedback-work.md
+++ b/docs/meta/gh-feedback-work.md
@@ -119,6 +119,7 @@ Rewrite, don't append. The PR body should read as if it always described the PR'
   ---
   🤖 Generated with [Claude Code](https://claude.com/claude-code)
   ```
+- **Cross-repo refs** in the rewritten body default to explicit markdown links — bare `<owner>/<repo>#<n>` shortcuts are unsafe whenever the org slug contains another repo name in the same org as a substring. GitHub's autolinker mangles those org-slug fragments by relinking the inner repo name (e.g. `idnerdidx/bulk#311` smears into nested autolinks via the `idx` substring). If the existing body still has bare cross-repo shortcuts, rewrite them to `[<repo> PR #<n>](https://github.com/<owner>/<repo>/pull/<n>)` form during this pass, keeping the `<owner>/<repo>` pattern out of the label. Same-repo `#<n>` references stay valid bare. See the cross-repo-refs convention in `meta/gh`.
 
 Write via the REST API — `gh pr edit` can surface the Projects-classic GraphQL deprecation as a failure on some repos even when the PATCH succeeds:
 
@@ -141,5 +142,6 @@ Print, in the terminal (not to GitHub):
 - Never post on the user's GitHub account without the attribution footer. (This skill doesn't post at all, but the rule stands for any future skill that borrows this workflow.)
 - If the user explicitly asks for a comment reply after the skill finishes, PRINT the intended text (including the footer) and let the user paste it themselves.
 - Don't resolve review conversations — only the reviewer can do that meaningfully. Pushing fixes + rewriting the body is enough signal.
+- Don't leave bare `<owner>/<repo>#<n>` cross-repo shortcuts in the rewritten PR body when the org slug contains another repo name in the same org as a substring. Replace with `[<repo> PR #<n>](https://github.com/<owner>/<repo>/pull/<n>)`, keeping the `<owner>/<repo>` pattern out of the label, or GitHub's autolinker will mangle the render. Same-repo `#<n>` is unaffected.
 - Don't force-push, don't rebase, don't skip hooks.
 - If classification is uncertain or feedback is contradictory, ASK the user before implementing.

--- a/docs/meta/gh-issue-create.md
+++ b/docs/meta/gh-issue-create.md
@@ -70,6 +70,7 @@ Rules:
 - Synthesize; do **not** quote transcript verbatim.
 - Do **not** include the agent's own deliberations or speculation.
 - Do **not** reference code identifiers, file paths, or function names. Issues are product-level.
+- **Cross-repo references** (citing PRs, issues, or related work in another repo) default to explicit markdown links — bare `<owner>/<repo>#<n>` shortcuts are unsafe whenever the org slug contains another repo name in the same org as a substring. GitHub's autolinker mangles those org-slug fragments by relinking the inner repo name (e.g. `idnerdidx/bulk#311` smears into nested autolinks via the `idx` substring; Plane mirrors the broken HTML). Write `[bulk PR #311](https://github.com/idnerdidx/bulk/pull/311)` or `[bulk #311](https://github.com/idnerdidx/bulk/issues/311)`, keeping the `<owner>/<repo>` pattern out of the label. Same-repo refs (`#<n>` with no `<owner>/<repo>/` prefix) stay valid bare. See the cross-repo-refs convention in `meta/gh`.
 - If the conversation doesn't contain a concrete ask, STOP and ask the user what the issue should be about.
 
 ### Regression causation — when the user references a past change
@@ -167,6 +168,7 @@ https://github.com/<owner>/<repo>/issues/<n>
 ## Guardrails
 
 - Don't include code identifiers / file paths / function names in the issue body. A short SHA in the `## Context` section is the one exception — it's causation metadata, not implementation detail.
+- Don't write bare `<owner>/<repo>#<n>` cross-repo shortcuts when the org slug contains another repo name in the same org as a substring. The autolinker re-tokenizes the org slug and the result renders as a smear of nested links (especially in Plane). Default to `[<repo> PR #<n>](https://github.com/<owner>/<repo>/pull/<n>)` or `[<repo> #<n>](https://github.com/<owner>/<repo>/issues/<n>)`, keeping the `<owner>/<repo>` pattern out of the label. Bare `#<n>` for same-repo refs is unaffected.
 - Don't post without explicit confirmation. Ever.
 - Don't open an issue in a repo the user didn't authorize (ask if ambiguous).
 - Don't open obvious duplicates — warn on near-match titles.

--- a/docs/meta/gh-issue-work.md
+++ b/docs/meta/gh-issue-work.md
@@ -193,6 +193,8 @@ Title: conventional-commits style, ≤70 chars.
 
 Body — product-focused, no file paths / line numbers / function names / symbol names. Describe what a user / operator / dealer experiences that they didn't before.
 
+**Cross-repo refs** in the body default to explicit markdown links — bare `<owner>/<repo>#<n>` shortcuts are unsafe whenever the org slug contains another repo name in the same org as a substring. GitHub's autolinker mangles those org-slug fragments by relinking the inner repo name (e.g. `idnerdidx/bulk#311` smears into nested autolinks via the `idx` substring). Write `[bulk PR #311](https://github.com/idnerdidx/bulk/pull/311)`, keeping the `<owner>/<repo>` pattern out of the label. Same-repo `Closes #<n>` lines stay bare. See the cross-repo-refs convention in `meta/gh`.
+
 ```
 gh pr create \
   --repo <owner>/<repo> \
@@ -234,6 +236,7 @@ GitHub-review-comment feedback (posted on the PR itself) is handled by `/gh-feed
 ## Guardrails
 
 - Don't reference code paths, symbols, or line numbers in the PR body. That belongs in the diff. The body is for the non-technical reader.
+- Don't write bare `<owner>/<repo>#<n>` cross-repo shortcuts in the PR body when the org slug contains another repo name in the same org as a substring. Default to `[<repo> PR #<n>](https://github.com/<owner>/<repo>/pull/<n>)`, keeping the `<owner>/<repo>` pattern out of the label, or GitHub's autolinker will mangle the render. Same-repo `Closes #<n>` is unaffected.
 - Don't open the PR without an explicit "Open PR as-is" from the user in Phase 8. A pushed branch is recoverable; an open PR pings reviewers.
 - Don't force-push, don't rebase shared branches, don't skip hooks.
 - Don't post issue/PR comments from this skill — the PR body carries all narrative.

--- a/docs/meta/gh-pr.md
+++ b/docs/meta/gh-pr.md
@@ -169,6 +169,8 @@ Skip nothing. If a subsection's scope didn't fire in the diff, note it didn't ap
 
 **Be terse.** Every point is a single short bullet — one sentence stating *what* and *where* (file:line). If the *why* isn't obvious, add one short sub-line; otherwise stop. No paragraphs. No "I checked X and verified Y by doing Z" prose. The author can read the diff — your job is to point at things, not explain them. If a finding needs more than two sentences to land, you haven't found the core of it yet.
 
+**Cross-repo refs in the review body** default to explicit markdown links — bare `<owner>/<repo>#<n>` shortcuts are unsafe whenever the org slug contains another repo name in the same org as a substring. GitHub's autolinker mangles those org-slug fragments by relinking the inner repo name (e.g. `idnerdidx/bulk#311` smears into nested autolinks via the `idx` substring). When citing a sibling repo's PR or issue from a review, write `[bulk PR #311](https://github.com/idnerdidx/bulk/pull/311)`, keeping the `<owner>/<repo>` pattern out of the label. File:line code refs and same-repo bare `#<n>` are unaffected. See the cross-repo-refs convention in `meta/gh`.
+
 Structure the body:
 
 1. **Lead** — one or two sentences. What the PR does, the verdict, and if blocking, the one-line summary of what's blocking. No more.
@@ -274,6 +276,7 @@ Then return the working tree to the repo's default branch so the user is left on
 - Never restate a point already made in the PR body, a prior review, a commit message, or the linked issue (Phase 4b).
 - Never omit the attribution footer.
 - Never quote secrets inline even when flagging — point at the line and describe the class.
+- Don't write bare `<owner>/<repo>#<n>` cross-repo shortcuts in the review body when the org slug contains another repo name in the same org as a substring. Default to `[<repo> PR #<n>](https://github.com/<owner>/<repo>/pull/<n>)`, keeping the `<owner>/<repo>` pattern out of the label, or GitHub's autolinker will mangle the render. File:line code refs and same-repo bare `#<n>` are unaffected.
 - Never ask the user something researchable. The repo, the KB, and the GitHub API are all reachable.
 - Never leave the user on the PR's branch when the skill ends if a plain `git checkout <default_branch>` would succeed. Don't stash, don't force — if git refuses, leave them put and report.
 - If `gh auth status` fails, surface the error and stop.

--- a/docs/meta/gh-pr.md
+++ b/docs/meta/gh-pr.md
@@ -43,6 +43,7 @@ Anything else → ask the user which PR via `AskUserQuestion`. Do not guess.
 
   The footer goes **inside** the heredoc (see the post template in Phase 6). Do not append it after the heredoc closes — that introduces stray newlines and can land outside the body.
 - **Code refs are fine in review bodies** (unlike issue/PR bodies). File paths, line numbers, function names, specific symbols — include them so the author can act. This is the one carve-out from the otherwise product-focused-bodies rule the rest of the `gh-*` family follows.
+- **Cross-repo references** (citing a sibling repo's PR or issue) default to explicit markdown links — bare `<owner>/<repo>#<n>` shortcuts are unsafe whenever the org slug contains another repo name in the same org as a substring. GitHub's autolinker mangles those org-slug fragments by relinking the inner repo name (e.g. `idnerdidx/bulk#311` smears into nested autolinks via the `idx` substring). Write `[bulk PR #311](https://github.com/idnerdidx/bulk/pull/311)` with the `<owner>/<repo>` pattern kept out of the label. Same-repo bare `#<n>` is unaffected. See the cross-repo-refs convention in `meta/gh`.
 
 ## Phase 0: Track progress
 

--- a/docs/meta/gh.md
+++ b/docs/meta/gh.md
@@ -22,7 +22,7 @@ related:
 
 One entry point for the five `gh-*` skills. Reads the conversation + any arguments, decides which sub-skill fits, and hands off. The sub-skills stay focused; this file is the dispatcher and the home for cross-skill conventions so they live in one place.
 
-## Cross-skill conventions (inherited by all three sub-skills)
+## Cross-skill conventions (inherited by all sub-skills)
 
 These apply to every sub-skill this router dispatches to. The sub-skill docs also state them, but the router is the canonical place.
 
@@ -40,6 +40,7 @@ These apply to every sub-skill this router dispatches to. The sub-skill docs als
 7. **Every issue posted carries the `plane` label.** The Plane management app mirrors GitHub issues based on this label. `gh-issue-create` owns applying it; this router just enforces that no other dispatch path bypasses it.
 8. **Never commit to or push from the default branch.** Before any `git commit`, verify the current branch is not the default branch. If it is, stop immediately and branch first. There is no valid case for committing directly to the default branch.
 9. **Never create a PR from a request that lacks an issue.** If the user asks to work on something and open a PR but does not specify an issue number, issue URL, or issue reference, route to `gh-issue-create` first. Only `gh-issue-work` may continue into PR creation, and only after an issue exists.
+10. **Cross-repo references use explicit markdown links by default — never the bare `<owner>/<repo>#<n>` shortcut when an org slug contains another repo name in the same org as a substring.** GitHub's Markdown autolinker re-tokenizes inside rendered text and eagerly relinks any org-slug fragment that matches a different repo in the same org. The canonical failure: the `idnerdidx` org contains a repo named `idx`, so a ref like `idnerdidx/bulk#311` renders as a smear of nested autolinks running through the org slug (the autolinker matches the `idx` substring inside `idnerdidx` as a candidate cross-repo ref to the `idx` repo, on top of the outer `idnerdidx/bulk` link). GitHub itself produces the mangled HTML; downstream mirrors like Plane carry it verbatim, where it shows up as a smear of repeated label fragments before the `#<n>`. The fix is `[<repo> PR #<n>](https://github.com/<owner>/<repo>/pull/<n>)` or `[<repo> #<n>](https://github.com/<owner>/<repo>/issues/<n>)`, with a label that contains **no `<owner>/<repo>` cross-repo pattern** the autolinker could re-match. Verifying that a given org has no substring trap requires knowing the org's full repo list, so default to the markdown-link form for any cross-repo ref — the extra characters are cheap insurance; check the rendered output before assuming a bare shortcut is safe. Same-repo refs (`#<n>` with no `<owner>/<repo>/` prefix) are always safe to leave bare.
 
 ## Inputs
 


### PR DESCRIPTION
## Summary
Closes #35 — cross-repo references in bodies posted by the `/gh` skill family no longer mangle on GitHub or downstream in Plane.

- New cross-skill convention in `/gh` requires markdown-link form for cross-repo refs whenever the org slug contains another repo name in the same org as a substring (the autolinker trap that smears `idnerdidx/bulk#311` into nested fragments).
- `/gh-issue-create`, `/gh-issue-work`, `/gh-feedback-work`, and `/gh-pr` each pick up the rule at their body-composition step and in their guardrails.
- `/gh-self-review` is unchanged (local-only — never posts to GitHub).
- Bare same-repo `#<n>` references (including `Closes #N`) stay valid; only the cross-repo shortcut form is restricted.
- Adjacent cleanup: the `## Cross-skill conventions` header in `gh.md` no longer claims "three sub-skills" when there are five.

## Test plan
- [ ] A future `/gh-issue-create` run that cites a sibling repo in the `idnerdidx` org produces markdown-link form, and the resulting issue renders cleanly on GitHub and Plane (no `bulk bulk bulk #311` smear).
- [ ] A future `/gh-issue-work` PR body cites cross-repo references in markdown-link form and renders cleanly on both surfaces.

## Known non-blockers
Surfaced by self-review and intentionally not folded in (deferrable):
- The fix-form was verified against GitHub's renderer (nested anchors are invalid HTML, so the autolinker doesn't re-tokenize inside an explicit-link label). End-to-end Plane verification will land naturally when the first cross-repo-citing issue is posted through the updated flow — captured in the test plan above.
- Convention #10 in `gh.md` is the longest entry in the numbered conventions list. Content is load-bearing (failure mode, canonical example, label rule, same-repo carve-out). Could be split into a one-line rule + a subsection if it becomes skim-hostile in practice.
- Some guardrail bullets use a short URL form and the body-composition step has the full URL — minor duplication, kept for the body-composition step to be the canonical reference.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
