### PR TITLE
Updating detritus now refreshes the cached MCP server binary

### DIFF
--- a/docs/meta/detritus-update.md
+++ b/docs/meta/detritus-update.md
@@ -9,7 +9,11 @@ triggers:
   - upgrade detritus
   - latest detritus
   - latest detritus release
-when: User asks to update or upgrade detritus, or to pull the latest detritus release.
+  - mcp serving old version
+  - kb_get not found after update
+  - stale cached binary
+  - detritus-codex cache
+when: User asks to update or upgrade detritus, to pull the latest detritus release, or reports the MCP server still serving an old version (e.g. a known kb doc returns "not found") after an update.
 ---
 
 # /detritus-update — Update to the latest release
@@ -22,7 +26,17 @@ The binary handles everything: checks the latest release on GitHub, downloads th
 
 1. Run `detritus --update` via Bash. Stream its output to the user.
 2. If the command reports "Already up to date", stop. Nothing else to do.
-3. If it updated, the new binary has already re-run `--setup`. Surface the new version from the command output and let the user know to restart their MCP client (IDE / Claude Code) so it picks up the new binary.
+3. If it updated, the new binary has already re-run `--setup`. Surface the new version from the command output.
+4. **Invalidate the cached bootstrap binary.** The detritus repo's project-level `.mcp.json` runs `scripts/detritus-mcp.js`, which downloads the binary into the cache and re-downloads **only when that file is missing — it never version-checks**. So `detritus --update` replaces the installed binary but leaves this cache stale, and any MCP client whose `cwd` is the detritus repo keeps serving the old version. Remove it so the bootstrap re-fetches on next launch (harmless if absent):
+   ```bash
+   rm -f "${DETRITUS_CACHE_DIR:-$HOME/.cache}/detritus-codex/detritus"
+   ```
+   Cache location per platform: Linux `$DETRITUS_CACHE_DIR` or `~/.cache/detritus-codex/detritus`; macOS `~/Library/Caches/detritus-codex/detritus`; Windows `%LOCALAPPDATA%\detritus-codex\detritus.exe`.
+5. Tell the user to restart their MCP client (IDE / Claude Code) so it picks up the new binary — and, inside the detritus repo, re-fetches the bootstrap binary cleared in step 4. The running MCP server keeps the old binary loaded in memory until then.
+
+## Symptom: MCP still serving the old version after an update
+
+If a `kb_get`/`kb_list` call returns "not found" for a doc you know exists in this release (e.g. a newly added `meta/*` doc), or the MCP otherwise behaves like an older version right after `detritus --update`, the cause is almost always the stale cached bootstrap binary from step 4. Confirm with `"${DETRITUS_CACHE_DIR:-$HOME/.cache}/detritus-codex/detritus" --version`, then clear the cache and restart the client.
 
 ## Don't
 

--- a/docs/meta/detritus-update.md
+++ b/docs/meta/detritus-update.md
@@ -26,17 +26,18 @@ The binary handles everything: checks the latest release on GitHub, downloads th
 
 1. Run `detritus --update` via Bash. Stream its output to the user.
 2. If the command reports "Already up to date", stop. Nothing else to do.
-3. If it updated, the new binary has already re-run `--setup`. Surface the new version from the command output.
-4. **Invalidate the cached bootstrap binary.** The detritus repo's project-level `.mcp.json` runs `scripts/detritus-mcp.js`, which downloads the binary into the cache and re-downloads **only when that file is missing — it never version-checks**. So `detritus --update` replaces the installed binary but leaves this cache stale, and any MCP client whose `cwd` is the detritus repo keeps serving the old version. Remove it so the bootstrap re-fetches on next launch (harmless if absent):
-   ```bash
-   rm -f "${DETRITUS_CACHE_DIR:-$HOME/.cache}/detritus-codex/detritus"
-   ```
-   Cache location per platform: Linux `$DETRITUS_CACHE_DIR` or `~/.cache/detritus-codex/detritus`; macOS `~/Library/Caches/detritus-codex/detritus`; Windows `%LOCALAPPDATA%\detritus-codex\detritus.exe`.
-5. Tell the user to restart their MCP client (IDE / Claude Code) so it picks up the new binary — and, inside the detritus repo, re-fetches the bootstrap binary cleared in step 4. The running MCP server keeps the old binary loaded in memory until then.
+3. If it updated, the new binary has already re-run `--setup`, which also clears the cached bootstrap binary the detritus repo's project-level `.mcp.json` uses. (That bootstrap, `scripts/detritus-mcp.js`, re-downloads **only when the cached file is missing — it never version-checks**, so clearing it during `--setup` is what lets an update actually reach an MCP client whose `cwd` is the detritus repo.) You don't need to clear anything by hand. Surface the new version from the command output.
+4. Tell the user to restart their MCP client (IDE / Claude Code) so it picks up the new binary — and, inside the detritus repo, re-fetches the freshly-cleared bootstrap binary. The running MCP server keeps the old binary loaded in memory until then.
 
 ## Symptom: MCP still serving the old version after an update
 
-If a `kb_get`/`kb_list` call returns "not found" for a doc you know exists in this release (e.g. a newly added `meta/*` doc), or the MCP otherwise behaves like an older version right after `detritus --update`, the cause is almost always the stale cached bootstrap binary from step 4. Confirm with `"${DETRITUS_CACHE_DIR:-$HOME/.cache}/detritus-codex/detritus" --version`, then clear the cache and restart the client.
+If, after updating and restarting, a `kb_get`/`kb_list` call still returns "not found" for a doc you know exists in this release (e.g. a newly added `meta/*` doc), the cached bootstrap binary is stale and wasn't cleared — e.g. the running binary predates automatic invalidation, or `DETRITUS_CACHE_DIR` points somewhere `--setup` didn't expect. Confirm with `"${DETRITUS_CACHE_DIR:-$HOME/.cache}/detritus-codex/detritus" --version`, then clear it manually and restart the client:
+
+```bash
+rm -f "${DETRITUS_CACHE_DIR:-$HOME/.cache}/detritus-codex/detritus"
+```
+
+Cache location per platform: Linux `$DETRITUS_CACHE_DIR` or `~/.cache/detritus-codex/detritus`; macOS `~/Library/Caches/detritus-codex/detritus`; Windows `%LOCALAPPDATA%\detritus-codex\detritus.exe`.
 
 ## Don't
 

--- a/main_test.go
+++ b/main_test.go
@@ -353,14 +353,15 @@ func TestCodexCacheBinaryDefaultPath(t *testing.T) {
 }
 
 func TestClearCodexCacheRemovesStaleBinary(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("DETRITUS_CACHE_DIR", dir)
-	binPath := filepath.Join(dir, cacheBinName())
+	// DETRITUS_CACHE_DIR overrides the home-derived path, so the home arg is irrelevant.
+	cacheDir := t.TempDir()
+	t.Setenv("DETRITUS_CACHE_DIR", cacheDir)
+	binPath := filepath.Join(cacheDir, cacheBinName())
 	if err := os.WriteFile(binPath, []byte("stale"), 0o755); err != nil {
 		t.Fatalf("seed cache: %v", err)
 	}
 
-	clearCodexCache(t.TempDir(), false)
+	clearCodexCache(homeDir(), false)
 
 	if fileExists(binPath) {
 		t.Fatal("expected stale cached MCP binary to be removed so the bootstrap re-fetches")
@@ -368,14 +369,15 @@ func TestClearCodexCacheRemovesStaleBinary(t *testing.T) {
 }
 
 func TestClearCodexCacheDryRunKeepsBinary(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("DETRITUS_CACHE_DIR", dir)
-	binPath := filepath.Join(dir, cacheBinName())
+	// DETRITUS_CACHE_DIR overrides the home-derived path, so the home arg is irrelevant.
+	cacheDir := t.TempDir()
+	t.Setenv("DETRITUS_CACHE_DIR", cacheDir)
+	binPath := filepath.Join(cacheDir, cacheBinName())
 	if err := os.WriteFile(binPath, []byte("stale"), 0o755); err != nil {
 		t.Fatalf("seed cache: %v", err)
 	}
 
-	clearCodexCache(t.TempDir(), true)
+	clearCodexCache(homeDir(), true)
 
 	if !fileExists(binPath) {
 		t.Fatal("dry-run must not remove the cached MCP binary")

--- a/main_test.go
+++ b/main_test.go
@@ -323,3 +323,61 @@ func TestGenerateInlineCommandInstructionsUsesCommandOnlyMap(t *testing.T) {
 		t.Fatal("expected unmapped slash fallback rule")
 	}
 }
+
+func cacheBinName() string {
+	if runtime.GOOS == "windows" {
+		return "detritus.exe"
+	}
+	return "detritus"
+}
+
+func TestCodexCacheBinaryHonorsEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DETRITUS_CACHE_DIR", dir)
+
+	got := codexCacheBinary(t.TempDir())
+	want := filepath.Join(dir, cacheBinName())
+	if got != want {
+		t.Fatalf("codexCacheBinary = %q, want %q", got, want)
+	}
+}
+
+func TestCodexCacheBinaryDefaultPath(t *testing.T) {
+	t.Setenv("DETRITUS_CACHE_DIR", "")
+
+	got := codexCacheBinary(t.TempDir())
+	suffix := filepath.Join("detritus-codex", cacheBinName())
+	if !strings.HasSuffix(got, suffix) {
+		t.Fatalf("codexCacheBinary = %q, want suffix %q", got, suffix)
+	}
+}
+
+func TestClearCodexCacheRemovesStaleBinary(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DETRITUS_CACHE_DIR", dir)
+	binPath := filepath.Join(dir, cacheBinName())
+	if err := os.WriteFile(binPath, []byte("stale"), 0o755); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	clearCodexCache(t.TempDir(), false)
+
+	if fileExists(binPath) {
+		t.Fatal("expected stale cached MCP binary to be removed so the bootstrap re-fetches")
+	}
+}
+
+func TestClearCodexCacheDryRunKeepsBinary(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("DETRITUS_CACHE_DIR", dir)
+	binPath := filepath.Join(dir, cacheBinName())
+	if err := os.WriteFile(binPath, []byte("stale"), 0o755); err != nil {
+		t.Fatalf("seed cache: %v", err)
+	}
+
+	clearCodexCache(t.TempDir(), true)
+
+	if !fileExists(binPath) {
+		t.Fatal("dry-run must not remove the cached MCP binary")
+	}
+}

--- a/setup.go
+++ b/setup.go
@@ -80,6 +80,11 @@ func RunSetup(binaryPath string, dryRun bool) error {
 		fmt.Println("Verdent not detected; skipping Verdent setup.")
 	}
 
+	// Bootstrap cache: scripts/detritus-mcp.js re-downloads the binary only when
+	// the cached file is missing, so invalidate it here or the in-repo MCP server
+	// keeps serving the previous version after an update.
+	clearCodexCache(home, dryRun)
+
 	// Post-install verification
 	if !dryRun {
 		printVerification(home)
@@ -650,4 +655,57 @@ func fileExists(path string) bool {
 func fileContains(path, substr string) bool {
 	data, err := os.ReadFile(path)
 	return err == nil && strings.Contains(string(data), substr)
+}
+
+// codexCacheBinary returns the path to the cached MCP bootstrap binary that
+// scripts/detritus-mcp.js downloads. Mirrors the path resolution in that
+// script: DETRITUS_CACHE_DIR overrides everything, otherwise it is the
+// platform cache dir plus "detritus-codex".
+func codexCacheBinary(home string) string {
+	binName := "detritus"
+	if runtime.GOOS == "windows" {
+		binName = "detritus.exe"
+	}
+	if dir := os.Getenv("DETRITUS_CACHE_DIR"); dir != "" {
+		return filepath.Join(dir, binName)
+	}
+	return filepath.Join(platformCacheDir(home), "detritus-codex", binName)
+}
+
+// platformCacheDir mirrors defaultCacheDir() in scripts/detritus-mcp.js.
+func platformCacheDir(home string) string {
+	switch runtime.GOOS {
+	case "windows":
+		if appdata := os.Getenv("LOCALAPPDATA"); appdata != "" {
+			return appdata
+		}
+		return filepath.Join(home, "AppData", "Local")
+	case "darwin":
+		return filepath.Join(home, "Library", "Caches")
+	default:
+		if xdg := os.Getenv("XDG_CACHE_HOME"); xdg != "" {
+			return xdg
+		}
+		return filepath.Join(home, ".cache")
+	}
+}
+
+// clearCodexCache deletes the cached MCP bootstrap binary so the next launch of
+// scripts/detritus-mcp.js re-fetches the freshly installed version. The
+// bootstrap only re-downloads when the file is missing, so this is what makes
+// an update actually reach an MCP client whose cwd is the detritus repo.
+func clearCodexCache(home string, dryRun bool) {
+	binPath := codexCacheBinary(home)
+	if !fileExists(binPath) {
+		return
+	}
+	if dryRun {
+		fmt.Printf("[dry-run] Would clear stale MCP bootstrap cache %s\n", binPath)
+		return
+	}
+	if err := os.Remove(binPath); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: could not clear cached MCP binary %s: %v\n", binPath, err)
+		return
+	}
+	fmt.Printf("Cleared stale MCP bootstrap cache: %s\n", binPath)
 }


### PR DESCRIPTION
## Summary
Closes #44 — updating detritus now takes effect for MCP clients without any manual cache cleanup.

- Previously, `detritus --update` installed the new version but clients running from the bundled cache kept serving the old one, so new or changed guidance silently failed to appear.
- The update now refreshes that cache itself; after a restart, clients pick up the new version.
- The only remaining manual step is restarting the client — the non-obvious "delete a cache file by hand" workaround is gone.
- Dry-run mode previews the refresh without deleting anything.

## Test plan
- [ ] After updating, a restarted MCP client serves the new version with no manual cache cleanup
- [ ] The update reports that the cache was refreshed
- [ ] Dry-run mode previews the refresh without deleting anything

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)