### PR TITLE
fix(setup): prune stale Claude Code commands on update

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -351,7 +351,9 @@ func generateClaudeSkills(home string, docs []docEntry) {
 		fmt.Fprintf(os.Stderr, "warning: claude skills dir: %v\n", err)
 		return
 	}
+	generated := map[string]bool{}
 	for _, doc := range docs {
+		generated[doc.alias] = true
 		skillDir := filepath.Join(skillsDir, doc.alias)
 		_ = os.MkdirAll(skillDir, 0o755)
 		desc := doc.desc
@@ -360,6 +362,22 @@ func generateClaudeSkills(home string, docs []docEntry) {
 		}
 		content := fmt.Sprintf("---\nname: %s\ndescription: %s\n---\n\nCall kb_get with name=\"%s\" and follow the instructions in the returned document.\n", doc.alias, desc, doc.name)
 		_ = os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644)
+	}
+	// Prune detritus-generated skills whose backing doc was removed in this
+	// release, so a deleted doc doesn't leave a dangling skill that kb_gets a
+	// missing document. Match only our own generated marker so hand-authored
+	// skills are never touched. Mirrors the stale-removal in generateCodexSkills
+	// and generateVerdentSkills.
+	entries, _ := os.ReadDir(skillsDir)
+	for _, e := range entries {
+		if !e.IsDir() || generated[e.Name()] {
+			continue
+		}
+		sf := filepath.Join(skillsDir, e.Name(), "SKILL.md")
+		data, err := os.ReadFile(sf)
+		if err == nil && strings.Contains(string(data), "Call kb_get with name=\"") {
+			os.RemoveAll(filepath.Join(skillsDir, e.Name()))
+		}
 	}
 	fmt.Printf("Claude Code skills: %s\n", skillsDir)
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestGenerateClaudeSkillsPrunesStale verifies that a detritus-generated skill
+// whose backing doc was removed gets pruned on the next setup, while a
+// hand-authored skill (no detritus marker) is left untouched and current docs
+// install as before.
+func TestGenerateClaudeSkillsPrunesStale(t *testing.T) {
+	home := t.TempDir()
+	skillsDir := filepath.Join(home, ".claude", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale detritus-generated skill (its doc was deleted) — carries our marker.
+	staleDir := filepath.Join(skillsDir, "audit-add")
+	if err := os.MkdirAll(staleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(staleDir, "SKILL.md"),
+		[]byte("---\nname: audit-add\ndescription: x\n---\n\nCall kb_get with name=\"meta/audit-add\" and follow the instructions in the returned document.\n"),
+		0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Hand-authored skill that even mentions kb_get in prose — but lacks the
+	// detritus generator marker, so it must survive (the false-positive the
+	// issue specifically warns against).
+	userDir := filepath.Join(skillsDir, "my-custom")
+	if err := os.MkdirAll(userDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userDir, "SKILL.md"),
+		[]byte("---\nname: my-custom\ndescription: mine\n---\n\nMy own workflow. It happens to call kb_get sometimes.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A directory with no SKILL.md at all — must be left alone (guards the
+	// err == nil branch from ever deleting unrelated dirs).
+	emptyDir := filepath.Join(skillsDir, "not-a-skill")
+	if err := os.MkdirAll(emptyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	generateClaudeSkills(home, []docEntry{{name: "meta/plan", alias: "plan", desc: "Plan things"}})
+
+	// Current doc installed.
+	if _, err := os.Stat(filepath.Join(skillsDir, "plan", "SKILL.md")); err != nil {
+		t.Fatalf("current skill not installed: %v", err)
+	}
+	// Stale detritus skill pruned.
+	if _, err := os.Stat(staleDir); !os.IsNotExist(err) {
+		t.Fatalf("stale detritus skill not pruned (stat err = %v)", err)
+	}
+	// Hand-authored skill (with a prose kb_get mention) preserved.
+	if _, err := os.Stat(filepath.Join(userDir, "SKILL.md")); err != nil {
+		t.Fatalf("hand-authored skill was removed: %v", err)
+	}
+	// SKILL.md-less directory left alone.
+	if _, err := os.Stat(emptyDir); err != nil {
+		t.Fatalf("directory without SKILL.md was removed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Closes #46 — after a detritus update that retires a knowledge doc, its Claude Code command no longer lingers as a broken command; the update removes it cleanly.

- Updating now prunes Claude Code commands whose backing doc was dropped in that release, instead of leaving them installed and failing when invoked.
- Only detritus-installed commands are pruned — a hand-authored skill is left untouched, even one that happens to mention the same tooling.
- Current commands still install and refresh exactly as before.
- Brings Claude Code in line with the Codex and Verdent setup paths, which already clean up removed commands on update.

## Test plan
- [x] After an update that removed a doc, the stale Claude Code command is pruned (unit test).
- [x] A hand-authored skill survives — including one with an incidental mention of the tooling — and a directory with no skill file is left alone.
- [x] Current commands still install/refresh.
- [ ] Manual: re-run `detritus --update` on a machine with a previously-removed command's leftover and confirm it disappears.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)