### PR TITLE
fix: load detritus tools in VS Code Copilot Chat

### DIFF
--- a/main.go
+++ b/main.go
@@ -330,10 +330,19 @@ func upsertMCP(file, parentKey, command string) {
 	if !ok {
 		parent = map[string]any{}
 	}
-	parent["detritus"] = map[string]any{
+	entry := map[string]any{
 		"command": command,
 		"args":    []any{},
 	}
+	// VS Code's native MCP host keys servers under "servers" and silently
+	// skips any entry without an explicit transport "type". Without this the
+	// gateway initializes but never starts detritus, so kb_*/code_* tools never
+	// reach Copilot Chat. Other hosts (Cursor/Windsurf use "mcpServers") infer
+	// stdio and don't need it, so only stamp it for the VS Code schema.
+	if parentKey == "servers" {
+		entry["type"] = "stdio"
+	}
+	parent["detritus"] = entry
 	data[parentKey] = parent
 
 	out, err := json.MarshalIndent(data, "", "  ")

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -381,5 +382,74 @@ func TestClearCodexCacheDryRunKeepsBinary(t *testing.T) {
 
 	if !fileExists(binPath) {
 		t.Fatal("dry-run must not remove the cached MCP binary")
+	}
+}
+
+func readUpsertedEntry(t *testing.T, file, parentKey string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	parent, ok := data[parentKey].(map[string]any)
+	if !ok {
+		t.Fatalf("missing parent key %q in %s", parentKey, file)
+	}
+	entry, ok := parent["detritus"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing detritus entry under %q in %s", parentKey, file)
+	}
+	return entry
+}
+
+// VS Code's native MCP host skips any server entry that lacks an explicit
+// transport "type", so upsertMCP must stamp "stdio" when writing under the
+// "servers" key. Other hosts key under "mcpServers" and infer stdio, so the
+// type must NOT be added there.
+func TestUpsertMCPStampsStdioForVSCodeServersKey(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "mcp.json")
+	upsertMCP(file, "servers", "/usr/local/bin/detritus")
+
+	entry := readUpsertedEntry(t, file, "servers")
+	if entry["type"] != "stdio" {
+		t.Fatalf("expected type=stdio for servers key, got %v", entry["type"])
+	}
+	if entry["command"] != "/usr/local/bin/detritus" {
+		t.Fatalf("expected command to be preserved, got %v", entry["command"])
+	}
+}
+
+func TestUpsertMCPOmitsTypeForMcpServersKey(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "mcp.json")
+	upsertMCP(file, "mcpServers", "/usr/local/bin/detritus")
+
+	entry := readUpsertedEntry(t, file, "mcpServers")
+	if _, ok := entry["type"]; ok {
+		t.Fatalf("expected no type for mcpServers key, got %v", entry["type"])
+	}
+}
+
+// The in-the-wild repair path: a config written by an older detritus has a
+// "servers.detritus" entry with no transport "type". Re-running setup must
+// upgrade it in place by adding "type":"stdio" so VS Code stops skipping it.
+func TestUpsertMCPUpgradesExistingServersEntryWithoutType(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "mcp.json")
+	seed := []byte(`{"servers":{"detritus":{"command":"/old/path","args":[]}}}`)
+	if err := os.WriteFile(file, seed, 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	upsertMCP(file, "servers", "/usr/local/bin/detritus")
+
+	entry := readUpsertedEntry(t, file, "servers")
+	if entry["type"] != "stdio" {
+		t.Fatalf("expected re-run to add type=stdio, got %v", entry["type"])
+	}
+	if entry["command"] != "/usr/local/bin/detritus" {
+		t.Fatalf("expected command to be refreshed, got %v", entry["command"])
 	}
 }


### PR DESCRIPTION
## Summary
Closes #50 — detritus knowledge base and code tools now load in VS Code Copilot Chat after setup.

- VS Code's MCP host silently ignored the detritus server because its config entry was missing the transport marker it requires, so the server registered but never started.
- Setup now writes that marker for the VS Code config while leaving every other supported tool (Codex, Cursor, Windsurf, Claude Code) untouched.
- Re-running setup repairs an existing VS Code config that predates this fix.

## Test plan
- [ ] Run setup for VS Code, open a fresh Copilot Chat agent session, confirm the detritus tools are available.
- [ ] Confirm other MCP hosts continue to work unchanged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)