### PR TITLE
chore(release): bump detritus to 3.18.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "detritus",
-    "version": "3.17.0",
+    "version": "3.18.0",
     "description": "Knowledge base plugin for the ooo ecosystem — coding patterns, testing workflows, and library documentation served via MCP tools and agent skills",
     "author": "benitogf",
     "repository": "https://github.com/benitogf/detritus"

--- a/plugins/detritus/.codex-plugin/plugin.json
+++ b/plugins/detritus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",


### PR DESCRIPTION
## Summary

Cuts the **v3.18.0** release, bundling the skill/meta changes merged since v3.17.0. Version bumped in all three plugin manifests (`plugin.json`, `.codex-plugin/plugin.json`, `plugins/detritus/.codex-plugin/plugin.json`).

## What's in this release

- **#55** — adds `/vibe`: executive intake that turns a one-line directive into an autonomous PR.
- **#53** — `/gh` and `/grow` now act on explicit instructions instead of re-asking what the user already specified.
- **#49** — `gh-feedback-work` preflight-checks that the PR has a linked issue.
- **#51** — stamps the stdio transport type for the VS Code MCP servers key.
- **#47** — prunes stale Claude Code skills on update.
- **#45** — invalidates the cached MCP bootstrap binary on setup so `--update` actually refreshes it.

## Notes

- The embedded search index (`generated/data.gob`) already reflects all current docs (regenerated in #55); a local `go generate` produces only non-deterministic keyword-ordering noise, so no index churn is included. CI regenerates the index fresh on tag push regardless.
- `go build`, `go vet`, and `go test ./...` all pass.

Tagging `v3.18.0` after merge triggers the goreleaser publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)