### PR TITLE
docs(grow): generalize lessons past the triggering incident

### DIFF
--- a/docs/meta/grow.md
+++ b/docs/meta/grow.md
@@ -96,6 +96,12 @@ Independently of user corrections, check the last interaction against establishe
 
 For each failure mode identified:
 
+### Generalize past the trigger
+The delta must encode the **underlying rule**, not the specific incident that surfaced it. The triggering case is at most **one illustrative example** — never the framing.
+- Ask "what is the *class* of changes that share this failure mode?" and write the rule for that class.
+- If the delta only fires for the exact situation that prompted the `/grow`, it is **overfit** — widen it until a reviewer hitting a *different* instance of the same problem still matches.
+- An example earns its place only as a parenthetical `e.g.`. If the example is doing the load-bearing work, the rule above it is too narrow — lift the general principle out of it.
+
 ### Prefer editing existing docs
 - If a relevant doc already covers the topic but is missing the specific guidance, propose an edit:
   - Target file path in `docs/`


### PR DESCRIPTION
## What

Adds a **"Generalize past the trigger"** rule to `/grow` Step 3, so each KB delta
encodes the general rule behind a correction rather than the specific incident
that surfaced it.

Closes #59.

## Why

`/grow` distils lessons from corrections, but nothing stopped a delta from being
**overfit** — pinned to the triggering example so tightly that a reviewer hitting
a different instance of the same failure mode wouldn't match. The new rule says
to encode the *class* of changes, keep the incident as at most one parenthetical
example, and widen any delta that only fires for the exact triggering situation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)