### PR TITLE
fix(codex): register detritus mcp during setup

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -439,30 +439,194 @@ func upsertTOMLTable(content, table string, body []string) string {
 	}
 
 	lines := strings.Split(content, "\n")
-	start := -1
-	for i, line := range lines {
-		if strings.TrimSpace(line) == header {
-			start = i
-			break
+	lines, inlineParentIndex := removeTOMLTableForms(lines, table)
+
+	if inlineParentIndex >= 0 {
+		parent, child, _ := strings.Cut(table, ".")
+		lines[inlineParentIndex] = upsertInlineTOMLTableValue(lines[inlineParentIndex], parent, child, body)
+		return strings.TrimRight(strings.Join(lines, "\n"), "\n") + "\n"
+	}
+
+	content = strings.TrimRight(strings.Join(lines, "\n"), "\n")
+	if content == "" {
+		return block + "\n"
+	}
+	return content + "\n\n" + block + "\n"
+}
+
+func removeTOMLTableForms(lines []string, table string) ([]string, int) {
+	parent, child, hasChild := strings.Cut(table, ".")
+	header := "[" + table + "]"
+	parentHeader := "[" + parent + "]"
+	inlineParentIndex := -1
+	section := ""
+	filtered := make([]string, 0, len(lines))
+
+	for i := 0; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == header {
+			for i+1 < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i+1]), "[") {
+				i++
+			}
+			continue
+		}
+
+		if strings.HasPrefix(trimmed, "[") {
+			section = trimmed
+			filtered = append(filtered, lines[i])
+			continue
+		}
+
+		if hasChild && section == "" && isInlineTOMLTableAssignment(trimmed, parent) {
+			inlineParentIndex = len(filtered)
+			filtered = append(filtered, lines[i])
+			continue
+		}
+
+		if hasChild && section == "" && isTOMLKeyFor(trimmed, table) {
+			continue
+		}
+
+		if hasChild && section == parentHeader && isTOMLKeyFor(trimmed, child) {
+			continue
+		}
+
+		filtered = append(filtered, lines[i])
+	}
+
+	return filtered, inlineParentIndex
+}
+
+func isTOMLKeyFor(trimmed, key string) bool {
+	return strings.HasPrefix(trimmed, key+".") || strings.HasPrefix(trimmed, key+" ") || strings.HasPrefix(trimmed, key+"=")
+}
+
+func isInlineTOMLTableAssignment(trimmed, key string) bool {
+	eq := strings.Index(trimmed, "=")
+	if eq < 0 || strings.TrimSpace(trimmed[:eq]) != key {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(trimmed[eq+1:]), "{")
+}
+
+func upsertInlineTOMLTableValue(line, parent, child string, body []string) string {
+	eq := strings.Index(line, "=")
+	if eq < 0 || strings.TrimSpace(line[:eq]) != parent {
+		return line
+	}
+
+	open := strings.Index(line[eq+1:], "{")
+	if open < 0 {
+		return line
+	}
+	open += eq + 1
+	close := findMatchingBrace(line, open)
+	if close < 0 {
+		return line
+	}
+
+	entries := splitInlineTOMLEntries(line[open+1 : close])
+	kept := entries[:0]
+	for _, entry := range entries {
+		if inlineTOMLEntryKey(entry) == child {
+			continue
+		}
+		kept = append(kept, entry)
+	}
+	kept = append(kept, child+" = "+inlineTOMLTableBody(body))
+
+	return line[:open+1] + " " + strings.Join(kept, ", ") + " " + line[close:]
+}
+
+func findMatchingBrace(value string, open int) int {
+	depth := 0
+	inString := false
+	escaped := false
+	for i := open; i < len(value); i++ {
+		ch := value[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inString = true
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
 		}
 	}
+	return -1
+}
 
-	if start < 0 {
-		return content + "\n\n" + block + "\n"
-	}
-
-	end := len(lines)
-	for i := start + 1; i < len(lines); i++ {
-		if strings.HasPrefix(strings.TrimSpace(lines[i]), "[") {
-			end = i
-			break
+func splitInlineTOMLEntries(value string) []string {
+	var entries []string
+	start := 0
+	depth := 0
+	inString := false
+	escaped := false
+	for i := 0; i < len(value); i++ {
+		ch := value[i]
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			if ch == '\\' {
+				escaped = true
+				continue
+			}
+			if ch == '"' {
+				inString = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inString = true
+		case '{', '[':
+			depth++
+		case '}', ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				if entry := strings.TrimSpace(value[start:i]); entry != "" {
+					entries = append(entries, entry)
+				}
+				start = i + 1
+			}
 		}
 	}
+	if entry := strings.TrimSpace(value[start:]); entry != "" {
+		entries = append(entries, entry)
+	}
+	return entries
+}
 
-	updated := append([]string{}, lines[:start]...)
-	updated = append(updated, blockLines...)
-	updated = append(updated, lines[end:]...)
-	return strings.TrimRight(strings.Join(updated, "\n"), "\n") + "\n"
+func inlineTOMLEntryKey(entry string) string {
+	eq := strings.Index(entry, "=")
+	if eq < 0 {
+		return ""
+	}
+	return strings.TrimSpace(entry[:eq])
+}
+
+func inlineTOMLTableBody(body []string) string {
+	return "{ " + strings.Join(body, ", ") + " }"
 }
 
 func tomlString(value string) string {

--- a/setup.go
+++ b/setup.go
@@ -71,7 +71,7 @@ func RunSetup(binaryPath string, dryRun bool) error {
 	setupClaudeCode(home, binaryPath, docs, dryRun)
 
 	// Codex
-	setupCodex(home, docs, dryRun)
+	setupCodex(home, binaryPath, docs, dryRun)
 
 	// Verdent
 	if verdentDetected(home) {
@@ -384,7 +384,7 @@ func generateClaudeSkills(home string, docs []docEntry) {
 
 // ---- Codex ------------------------------------------------------------------
 
-func setupCodex(home string, docs []docEntry, dryRun bool) {
+func setupCodex(home, binaryPath string, docs []docEntry, dryRun bool) {
 	codexDir := filepath.Join(home, ".codex")
 	if !dirExists(codexDir) {
 		fmt.Println("Codex not detected; skipping Codex setup.")
@@ -392,13 +392,85 @@ func setupCodex(home string, docs []docEntry, dryRun bool) {
 	}
 
 	skillsDir := filepath.Join(codexDir, "skills")
+	configFile := filepath.Join(codexDir, "config.toml")
 	if dryRun {
+		fmt.Printf("[dry-run] Would upsert detritus into %s (mcp_servers)\n", configFile)
 		fmt.Printf("[dry-run] Would write %d Codex skill files to %s\n", len(docs), skillsDir)
 		return
 	}
 
+	upsertCodexMCPConfig(configFile, binaryPath)
 	generateCodexSkills(skillsDir, docs)
+	fmt.Printf("Codex MCP config: %s\n", configFile)
 	fmt.Printf("Codex skills: %s\n", skillsDir)
+}
+
+func upsertCodexMCPConfig(file, command string) {
+	content := ""
+	if raw, err := os.ReadFile(file); err == nil {
+		content = string(raw)
+	}
+
+	content = upsertTOMLTable(content, "mcp_servers.detritus", []string{
+		"command = " + tomlString(command),
+		"args = []",
+	})
+
+	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to create Codex config directory: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(file, []byte(content), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", file, err)
+		os.Exit(1)
+	}
+}
+
+func upsertTOMLTable(content, table string, body []string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.TrimRight(content, "\n")
+
+	header := "[" + table + "]"
+	blockLines := append([]string{header}, body...)
+	block := strings.Join(blockLines, "\n")
+
+	if content == "" {
+		return block + "\n"
+	}
+
+	lines := strings.Split(content, "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == header {
+			start = i
+			break
+		}
+	}
+
+	if start < 0 {
+		return content + "\n\n" + block + "\n"
+	}
+
+	end := len(lines)
+	for i := start + 1; i < len(lines); i++ {
+		if strings.HasPrefix(strings.TrimSpace(lines[i]), "[") {
+			end = i
+			break
+		}
+	}
+
+	updated := append([]string{}, lines[:start]...)
+	updated = append(updated, blockLines...)
+	updated = append(updated, lines[end:]...)
+	return strings.TrimRight(strings.Join(updated, "\n"), "\n") + "\n"
+}
+
+func tomlString(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	value = strings.ReplaceAll(value, "\"", "\\\"")
+	value = strings.ReplaceAll(value, "\n", "\\n")
+	value = strings.ReplaceAll(value, "\r", "\\r")
+	return "\"" + value + "\""
 }
 
 func generateCodexSkills(skillsDir string, docs []docEntry) {

--- a/setup_test.go
+++ b/setup_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -64,5 +65,71 @@ func TestGenerateClaudeSkillsPrunesStale(t *testing.T) {
 	// SKILL.md-less directory left alone.
 	if _, err := os.Stat(emptyDir); err != nil {
 		t.Fatalf("directory without SKILL.md was removed: %v", err)
+	}
+}
+
+func TestUpsertTOMLTableAddsDetritusMCP(t *testing.T) {
+	input := `model = "gpt-5.5"
+
+[mcp_servers.node_repl]
+command = "node-repl"
+args = []
+`
+
+	got := upsertTOMLTable(input, "mcp_servers.detritus", []string{
+		`command = "C:\\detritus.exe"`,
+		"args = []",
+	})
+
+	if !strings.Contains(got, "[mcp_servers.node_repl]\ncommand = \"node-repl\"") {
+		t.Fatalf("existing node_repl table was not preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.detritus]\ncommand = \"C:\\\\detritus.exe\"\nargs = []") {
+		t.Fatalf("detritus table was not added:\n%s", got)
+	}
+}
+
+func TestUpsertTOMLTableReplacesExistingDetritusMCP(t *testing.T) {
+	input := `model = "gpt-5.5"
+
+[mcp_servers.detritus]
+command = "old"
+args = ["--old"]
+
+[mcp_servers.node_repl]
+command = "node-repl"
+`
+
+	got := upsertTOMLTable(input, "mcp_servers.detritus", []string{
+		`command = "new"`,
+		"args = []",
+	})
+
+	if strings.Contains(got, "old") || strings.Contains(got, "--old") {
+		t.Fatalf("old detritus table content was not replaced:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.detritus]\ncommand = \"new\"\nargs = []") {
+		t.Fatalf("new detritus table missing:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.node_repl]\ncommand = \"node-repl\"") {
+		t.Fatalf("following table was not preserved:\n%s", got)
+	}
+}
+
+func TestUpsertCodexMCPConfigWritesEscapedWindowsPath(t *testing.T) {
+	config := filepath.Join(t.TempDir(), "config.toml")
+
+	upsertCodexMCPConfig(config, `C:\Users\Owner\AppData\Local\detritus-codex\detritus.exe`)
+
+	raw, err := os.ReadFile(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(raw)
+	if !strings.Contains(got, `[mcp_servers.detritus]`) {
+		t.Fatalf("detritus table missing:\n%s", got)
+	}
+	if !strings.Contains(got, `command = "C:\\Users\\Owner\\AppData\\Local\\detritus-codex\\detritus.exe"`) {
+		t.Fatalf("windows path was not escaped as a TOML basic string:\n%s", got)
 	}
 }

--- a/setup_test.go
+++ b/setup_test.go
@@ -116,6 +116,96 @@ command = "node-repl"
 	}
 }
 
+func TestUpsertTOMLTableReplacesParentDottedDetritusMCP(t *testing.T) {
+	input := `model = "gpt-5.5"
+
+[mcp_servers]
+detritus.command = "old-detritus"
+detritus.args = ["--old"]
+node_repl.command = "node-repl"
+`
+
+	got := upsertTOMLTable(input, "mcp_servers.detritus", []string{
+		`command = "new-detritus"`,
+		"args = []",
+	})
+
+	if strings.Contains(got, "old-detritus") || strings.Contains(got, `detritus.command`) {
+		t.Fatalf("old parent-table dotted detritus entry was not replaced:\n%s", got)
+	}
+	if !strings.Contains(got, `node_repl.command = "node-repl"`) {
+		t.Fatalf("sibling parent-table entry was not preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.detritus]\ncommand = \"new-detritus\"\nargs = []") {
+		t.Fatalf("canonical detritus table missing:\n%s", got)
+	}
+	again := upsertTOMLTable(got, "mcp_servers.detritus", []string{
+		`command = "new-detritus"`,
+		"args = []",
+	})
+	if got != again {
+		t.Fatalf("upsert was not stable after parent-table migration:\nfirst:\n%s\nsecond:\n%s", got, again)
+	}
+}
+
+func TestUpsertTOMLTableReplacesTopLevelDottedDetritusMCP(t *testing.T) {
+	input := `model = "gpt-5.5"
+mcp_servers.detritus.command = "old-detritus"
+mcp_servers.detritus.args = ["--old"]
+mcp_servers.node_repl.command = "node-repl"
+`
+
+	got := upsertTOMLTable(input, "mcp_servers.detritus", []string{
+		`command = "new-detritus"`,
+		"args = []",
+	})
+
+	if strings.Contains(got, "old-detritus") || strings.Contains(got, `mcp_servers.detritus.command`) {
+		t.Fatalf("old top-level dotted detritus entry was not replaced:\n%s", got)
+	}
+	if !strings.Contains(got, `mcp_servers.node_repl.command = "node-repl"`) {
+		t.Fatalf("sibling top-level dotted entry was not preserved:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.detritus]\ncommand = \"new-detritus\"\nargs = []") {
+		t.Fatalf("canonical detritus table missing:\n%s", got)
+	}
+	again := upsertTOMLTable(got, "mcp_servers.detritus", []string{
+		`command = "new-detritus"`,
+		"args = []",
+	})
+	if got != again {
+		t.Fatalf("upsert was not stable after top-level dotted migration:\nfirst:\n%s\nsecond:\n%s", got, again)
+	}
+}
+
+func TestUpsertTOMLTableUpdatesInlineParentTable(t *testing.T) {
+	input := `model = "gpt-5.5"
+mcp_servers = { node_repl = { command = "node-repl", args = [] }, detritus = { command = "old-detritus", args = ["--old"] } }
+`
+
+	got := upsertTOMLTable(input, "mcp_servers.detritus", []string{
+		`command = "new-detritus"`,
+		"args = []",
+	})
+
+	if strings.Contains(got, "old-detritus") || strings.Contains(got, "[mcp_servers.detritus]") {
+		t.Fatalf("inline parent table should update in place without appending a subtable:\n%s", got)
+	}
+	if !strings.Contains(got, `node_repl = { command = "node-repl", args = [] }`) {
+		t.Fatalf("sibling inline entry was not preserved:\n%s", got)
+	}
+	if !strings.Contains(got, `detritus = { command = "new-detritus", args = [] }`) {
+		t.Fatalf("inline detritus entry was not updated:\n%s", got)
+	}
+	again := upsertTOMLTable(got, "mcp_servers.detritus", []string{
+		`command = "new-detritus"`,
+		"args = []",
+	})
+	if got != again {
+		t.Fatalf("inline parent-table upsert was not stable:\nfirst:\n%s\nsecond:\n%s", got, again)
+	}
+}
+
 func TestUpsertCodexMCPConfigWritesEscapedWindowsPath(t *testing.T) {
 	config := filepath.Join(t.TempDir(), "config.toml")
 


### PR DESCRIPTION
## Summary
Closes #61 — Codex setup now registers Detritus as a launchable knowledge server so fresh Codex sessions can use the knowledge tools after setup.

- Keeps existing Codex MCP entries intact while adding Detritus.
- Makes repeated setup runs stable across canonical tables, dotted keys, and inline Codex MCP entries.
- Preserves setup behavior for the other supported clients.

## Test plan
- [x] Targeted setup and MCP server tests pass.
- [x] Alternate Codex MCP TOML shapes are covered by regression tests.
- [x] Re-running setup against a temporary Codex home keeps the config stable.
- [x] A fresh Codex process can call the Detritus knowledge tools.
- [ ] Full test suite is green. Current main already fails an unrelated Claude guard test on this machine.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)