### PR TITLE
chore(release): bump detritus to 3.19.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "detritus",
-    "version": "3.18.0",
+    "version": "3.19.0",
     "description": "Knowledge base plugin for the ooo ecosystem — coding patterns, testing workflows, and library documentation served via MCP tools and agent skills",
     "author": "benitogf",
     "repository": "https://github.com/benitogf/detritus"

--- a/plugins/detritus/.codex-plugin/plugin.json
+++ b/plugins/detritus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",


### PR DESCRIPTION
## detritus 3.19.0

Bumps the version across all three `plugin.json` manifests (`plugin.json`, `.codex-plugin/plugin.json`, `plugins/detritus/.codex-plugin/plugin.json`) from `3.18.0` → `3.19.0`. Merging and tagging `v3.19.0` triggers the release workflow (regenerates the embedded search index via `go generate`, then goreleaser builds and publishes the binaries).

### Changes since v3.18.0

- **#62 fix(codex)** — register the detritus MCP server during setup and handle alternate MCP toml shapes, so Codex picks up detritus reliably.
- **#66 docs(smith)** — add a context-economy contract to `/smith` + loop-core; list all generic State-block fields instead of a partial four.
- **#64 docs(patterns)** — add the terse-comments rule to the code-style doc and the always-on guardrail surfaces (with the exported-API carve-out).
- **#60 docs(grow)** — require generalizing deltas past the triggering incident.
- **#58 docs(review-rigor)** — add the lived-path end-to-end runtime trace requirement and generalize the boundary-rules bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
