### PR TITLE
todo: evict completed items instead of archiving (bound the store)

### DIFF
--- a/docs/meta/todo-add.md
+++ b/docs/meta/todo-add.md
@@ -29,7 +29,7 @@ If text is missing, ask the user one concise question and stop.
 ## Phase 1: Read the store
 
 - Resolve `~/.claude/projects/<slug>/todos.json` (Phase 0 of `meta/todo`).
-- If missing, lazily create with `{ version: 1, epoch: 0, items: [], archive: [] }` and continue (schema defined in `meta/todo` convention #2).
+- If missing, lazily create with `{ version: 2, epoch: 0, items: [] }` and continue (schema defined in `meta/todo` convention #2).
 - Capture `epoch`.
 
 ## Phase 2: Infer scope + priority (Haiku sub-agent)
@@ -104,7 +104,6 @@ If the user passed an explicit tier hint (`--p0` etc.), honor it but let the sub
   "priority": <from Phase 2>,
   "scope": <from Phase 2 — includes evidence array>,
   "addedAt": "<ISO timestamp>",
-  "completedAt": null,
   "deferredUntil": null,
   "forkSession": null,
   "deps": [],
@@ -141,4 +140,4 @@ If `group` was null (no clear cluster), append: *"No group inferred — item is 
   - On any match, surface the candidates via `AskUserQuestion` by **positional index** (`1.`, `2.`, ...) — never by internal id, per convention #11 — and ask whether this is a new item, a refinement of an existing one (which should be a `/todo-edit` instead), or a merge candidate (append evidence/body to the existing).
 - Don't fabricate scope. If the sub-agent can't infer a concrete scope from the text + recent conversation, the item gets `concreteness: ambiguous` — don't guess paths to look concrete.
 - Don't ignore the epoch-check on write. Always re-read before write; restart on epoch mismatch.
-- Don't write to the archive section. Items always land in `items` first.
+- New items always land in `items` with `status: open`. There is no archive (completed items are evicted by `/todo-done`, not stored).

--- a/docs/meta/todo-claim.md
+++ b/docs/meta/todo-claim.md
@@ -29,7 +29,7 @@ Set `status: in-progress` and stamp `forkSession` so the parent conversation (an
 - Read the store.
 - Find the item.
 - If the item is already `in-progress` with a different `forkSession`, refuse the claim and surface the existing lock: *"t_005 is claimed by fork-2a — cannot claim from this session."* The user can `/todo claim t_005 --release` from the original fork (or override with `--force` if it's clear the original session is dead).
-- If the item is `done` or `failed`, refuse — the item is settled.
+- If the item is `failed`, refuse — the item is settled. (A completed item can't be claimed: `/todo-done` evicts it from the store, so it no longer exists to claim.)
 - If the item is `deferred`, ask the user to confirm — claiming a deferred item un-defers it.
 
 ## Phase 2: Derive the fork session id
@@ -68,7 +68,7 @@ Released t_005 (was fork-1). Item back to open status; available for re-ranking.
 
 A claimed item leaves the fork lifecycle in one of three ways:
 
-1. **Completed** — fork runs `/todo-done t_005`. Status → `done`, `forkSession` cleared, `completedAt` stamped.
+1. **Completed** — fork runs `/todo-done t_005`. The item is removed from the store (eviction, not a retained `done` status); its `forkSession` lock goes with it.
 2. **Released** — fork runs `/todo-claim t_005 --release`. Status → `open`, `forkSession` cleared. The work isn't done; the item is back in the active pool.
 3. **Failed** — fork detected it can't complete the work (e.g., scope was wrong, blocker discovered). Current path: run `/todo-claim --release` so the item returns to `open` status, and add a `failed-once` tag via `/todo-edit --tag failed-once` to capture the prior attempt. The item is back in the active pool for re-ranking. A first-class `failed` status with a `⚠ FAILED:` render in /todo-view is documented in the schema but lacks a direct user-facing setter — a future `--status` flag on `/todo-edit` or `/todo-done` would close this gap.
 

--- a/docs/meta/todo-clear.md
+++ b/docs/meta/todo-clear.md
@@ -1,61 +1,59 @@
 ---
-description: Archive completed items from the active todo list. Items move from `items` to `archive`; nothing is deleted.
+description: Prune failed and deferred items from the active todo list. Completed items already auto-evict on /todo-done; this removes the non-active states you no longer want.
 category: meta
 triggers:
   - todo-clear
-  - clear todos
-  - archive completed
+  - prune todos
+  - drop failed
   - clean up todos
-when: User wants the active list trimmed of done items without losing history.
+when: User wants the active list trimmed of failed/deferred items they no longer intend to act on.
 related:
   - meta/todo
   - meta/todo-done
+  - meta/todo-defer
 ---
 
-# /todo-clear — Archive Completed Items
+# /todo-clear — Prune Failed / Deferred Items
 
 _Follows `meta/todo` convention #13: main session validates input + calls TodoWrite + prints the confirmation line; the phases below describe the work the delegated sub-agent performs._
 
-Move items with `status: done` from `items` to `archive`. Active list stays focused; history stays intact for later inspection.
+Remove items the user has given up on. There is no archive, and `done` items are already evicted by `/todo-done` (see `meta/todo` #4), so this skill exists only to prune the lingering non-active states — `failed` and, on request, `deferred`.
 
 ## Inputs
 
-- `/todo clear` — archive all `done` items. Default.
-- `/todo clear --before <duration>` — only archive items completed more than `<duration>` ago (uses the same relative-duration parser as `/todo-defer`: `+7d`, `+1w`, etc.). Useful if you want to keep recently-completed items visible for context.
-- `/todo clear --failed` — also archive items with `status: failed`. Default excludes failed items because the user usually wants them visible for retry.
+- `/todo clear` — remove all `failed` items. Default (`failed` = a fork reported it couldn't finish; clearing means "I'm not retrying it").
+- `/todo clear --deferred` — also remove `deferred` items (snoozed work you've decided to drop).
+- `/todo clear --before <duration>` — only remove matching items older than `<duration>` (same relative-duration parser as `/todo-defer`: `+7d`, `+1w`, etc.), keyed off `deferredUntil` for deferred items and `editedAt`/`addedAt` for failed ones.
+
+`/todo clear` never touches `open` or `in-progress` items — those are the active working set.
 
 ## Phase 1: Read
 
 - Read the store.
-- Identify items to archive based on flags.
+- Identify items to remove based on flags.
 
 ## Phase 2: Confirm if non-trivial
 
-If more than 10 items would be archived in one pass, surface the count and ask via `AskUserQuestion` whether to proceed. Otherwise proceed silently.
+If more than 10 items would be removed in one pass, surface the count and ask via `AskUserQuestion` whether to proceed. Otherwise proceed silently.
 
 ## Phase 3: Mutate
 
 - Capture `epoch`.
-- For each item to archive: move from `items` to `archive`, preserving all fields including `completedAt`.
-- Bump `epoch`, update `updatedAt`, write atomically.
+- Delete each matching item from `items` (removal — there is no archive).
+- Bump `epoch`, update `updatedAt`, write atomically. The store is small, so rewrite it wholesale with `Write`/`Edit` — never shell out to a script (convention #3).
 
 ## Phase 3b: TodoWrite sync
 
-Per `meta/todo` convention #10, call `TodoWrite` with the current open + in-progress items (archived items disappear). Keeps the IDE UI consistent with the JSON.
+Per `meta/todo` convention #10, call `TodoWrite` with the current open + in-progress items (the pruned items disappear). Keeps the IDE UI consistent with the JSON.
 
 ## Phase 4: Report
 
 ```
-Archived 4 done items. Active list now has 11 open + 2 in-progress items.
+Pruned 3 failed items. Active list now has 11 open + 2 in-progress items.
 ```
-
-## Restoring from archive
-
-Not supported. The `archive` array is read-only. To "restore" an archived item, use `/todo-add` with the same text — it'll get a new id and a fresh priority.
 
 ## Guardrails
 
-- Never delete items. `archive` is a move, not a drop.
-- Don't archive `in-progress` items even if their `forkSession` is null — `in-progress` means actively claimed, not done.
-- Don't archive deferred items. Deferral is a temporary state; archiving would lose the deferral context.
-- Confirmation gate at >10 items is a soft warning, not a hard block. A future `--yes` flag could skip the gate if the volume of completed items makes the confirmation friction repetitive.
+- Removal is permanent. There is no archive to restore from — to bring an item back, `/todo-add` it again (new id, fresh priority). The >10-item confirmation gate keeps a bulk prune from being a surprise.
+- Don't remove `open` or `in-progress` items. `/todo-clear` only prunes `failed` (and, with `--deferred`, `deferred`). Active work is never cleared.
+- `done` items never reach this skill — `/todo-done` already evicted them. If you find `done` items in a store, it's an un-migrated v1 store; the next mutation's v1→v2 migration removes them (see `meta/todo` #2).

--- a/docs/meta/todo-defer.md
+++ b/docs/meta/todo-defer.md
@@ -44,7 +44,7 @@ If duration is missing, ask. If id is missing, near-match nudge.
 
 - Read the store.
 - Resolve `<id>` per `/todo-done` Phase 1: accept internal id OR fuzzy substring match; positional-index disambiguation.
-- If the item is `done`, `failed`, or already deferred with a future `deferredUntil`, surface the current state and ask whether to overwrite the deferral or cancel.
+- If the item is `failed`, or already deferred with a future `deferredUntil`, surface the current state and ask whether to overwrite the deferral or cancel. (There is no `done` state to check — completed items are evicted from the store.)
 - If the item has `status: in-progress` with `forkSession` set, refuse the defer — *"Item is in-flight in a fork; release it from the fork first, or complete it via /todo done."*
 
 ## Phase 2: Parse the duration

--- a/docs/meta/todo-done.md
+++ b/docs/meta/todo-done.md
@@ -1,5 +1,5 @@
 ---
-description: Mark a todo as done. Sub-agent re-prioritizes survivors so the next-up item reflects what's actually next.
+description: Mark a todo done — removes it from the active store (no archive). Sub-agent re-prioritizes survivors so the next-up item reflects what's actually next.
 category: meta
 triggers:
   - todo-done
@@ -17,7 +17,7 @@ related:
 
 _Follows `meta/todo` convention #13: main session validates input + calls TodoWrite + prints the confirmation line; the phases below describe the work the delegated sub-agent performs._
 
-Set an item's status to `done`, stamp `completedAt`, and let a Haiku sub-agent quickly re-rank the surviving open items.
+Remove the completed item from the store — "done" is eviction, not a retained status — and let a Haiku sub-agent quickly re-rank the surviving open items. The store stays bounded to the active working set; completion history lives in the PR/issue/git the item cited.
 
 ## Inputs
 
@@ -36,14 +36,14 @@ Per `meta/todo` convention #11, when fuzzy match is ambiguous list candidates by
   3. If 0 matches, print "no matching item" and stop.
   4. If 1 match, proceed.
   5. If >1 matches, list candidates by positional index (`1. <text>`, `2. <text>`, ...) — never showing internal ids — and ask the user to pick a number via `AskUserQuestion`.
-- If the item is already `done`, surface a one-line note ("Already done: <text>.") and stop.
+- (No "already done" guard is needed: completed items are removed from the store, so any resolved match is still active.)
 - If the item is `in-progress` with `forkSession` set, surface a one-line warning: *"This item is claimed by a fork — confirm you want to mark it done from this session and release the fork."* and ask the user to confirm. Don't reveal the fork id in the user-facing message.
 
 ## Phase 2: Mutate
 
-- Set `status: "done"`, `completedAt: <ISO timestamp>`.
-- If the item had `forkSession`, clear it (`forkSession: null`).
-- Capture `epoch` before mutating; epoch-check on write per `meta/todo` convention #3.
+- **Remove the item from `items`.** `/todo-done` evicts it — it does NOT set a `done` status or stamp `completedAt`, and there is no `archive` to move it to.
+- If the item had `forkSession`, the eviction releases the fork (the row is gone).
+- Capture `epoch` before mutating; epoch-check on write per `meta/todo` convention #3. The post-eviction store is small, so rewrite it wholesale with `Write`/`Edit` — never shell out to a script (convention #3).
 
 ## Phase 3: Quick re-rank (Haiku sub-agent)
 
@@ -79,5 +79,5 @@ If no survivors were rescored, just print the first sentence ("Marked done: <tex
 
 - Don't mark done without resolving the input to exactly one item. Internal id and fuzzy text both resolve; on multi-match, surface candidates by positional index per `meta/todo` convention #11 and require the user to pick before mutating. Never proceed on an ambiguous match.
 - Don't auto-release a forked claim silently. Always confirm with the user when the item being marked done has `forkSession` set.
-- Don't move the item to `archive` on `done`. Archiving is `/todo-clear`'s job; this skill only changes status.
+- Done means eviction, not archival. `/todo-done` removes the item outright — there is no `archive` and no retained `done` status. Completion history lives in the cited PR/issue/git, not the store.
 - Don't skip the rescore pass. Even if no items get changed, the sub-agent's check is what gives the user confidence the next-up item is current.

--- a/docs/meta/todo-edit.md
+++ b/docs/meta/todo-edit.md
@@ -72,8 +72,8 @@ Instead:
 3. After `/todo-import` returns, ask the user via `AskUserQuestion` what to do with the parent item:
    - **Keep as rollup** (default): leave the parent's title + body + priority intact; it stays as the high-level goal alongside the new sub-tasks.
    - **Lower priority** to sort below the sub-tasks (parent becomes a context note).
-   - **Mark done** since it's been decomposed.
-   - **Drop** (archive immediately).
+   - **Mark done** (evict via `/todo-done`) since it's been decomposed.
+   - **Drop** (delete it outright — abandon rather than complete).
 4. Apply the user's choice as a normal edit on the parent.
 
 **Forbidden**: writing a `steps`, `breakdown`, `subtasks`, or any custom array field on the parent item. The schema in `meta/todo` is the only one; any extension fields are out-of-spec and `/todo-audit` will surface them as schema violations to be migrated to individual items.

--- a/docs/meta/todo-file.md
+++ b/docs/meta/todo-file.md
@@ -15,12 +15,11 @@ related:
 
 _Follows `meta/todo` convention #13: main session validates input + calls TodoWrite + prints the confirmation line; the phases below describe the work the delegated sub-agent performs._
 
-Output the absolute path to `~/.claude/projects/<slug>/todos.json`. Read-only; the path-resolution + optional archive-size summary runs in a Haiku sub-agent per convention #13.
+Output the absolute path to `~/.claude/projects/<slug>/todos.json`. Read-only; the path-resolution runs in a Haiku sub-agent per convention #13.
 
 ## Inputs
 
 - `/todo file` — print the path.
-- `/todo file --archive` — print the path plus a one-line summary of the archive size.
 - `/todo file --json` — print the path plus a hint to `cat` it if the user wants to inspect.
 
 ## Phase 1: Resolve
@@ -32,13 +31,6 @@ Output the absolute path to `~/.claude/projects/<slug>/todos.json`. Read-only; t
 
 ```
 /Users/clinton/.claude/projects/c--ClintonStuff-github/todos.json
-```
-
-With `--archive`:
-
-```
-/Users/clinton/.claude/projects/c--ClintonStuff-github/todos.json
-Archive: 47 completed items (oldest 2026-04-12, newest 2026-05-29).
 ```
 
 With `--json`:

--- a/docs/meta/todo-fork.md
+++ b/docs/meta/todo-fork.md
@@ -61,7 +61,7 @@ If **any** item in a candidate group fails **either** gate, the group is rejecte
 ## Phase 1: Read + scan
 
 - Read the store.
-- Filter to active open items (exclude `in-progress`, `deferred`, `done`, `failed`).
+- Filter to active open items (exclude `in-progress`, `deferred`, `failed`). There is no `done` state — completed items are evicted from the store.
 - Capture `epoch`.
 
 ## Phase 2: Sonnet sub-agent identifies groups

--- a/docs/meta/todo-idle.md
+++ b/docs/meta/todo-idle.md
@@ -34,7 +34,7 @@ Same as `/todo-audit` Phase 1.
 Pass to the sub-agent:
 - Full active items list with current priority and scope.
 - Last 20–40 conversation turns (or a summary if longer) — broader context than `/todo-audit` since idle-mode wants strategic ranking, not just pivot-reactive.
-- The user's recent completed items (last 5–10 from `archive`) so the sub-agent can infer current focus areas.
+- The user's recent activity from the conversation + recent git/PR context so the sub-agent can infer current focus areas (completed items aren't retained in the store — they're evicted on `/todo-done`).
 - Any `/janitor` scratchpad hazards if `.janitor/` exists.
 
 The sub-agent returns a re-ranking plus a `contentious` array:

--- a/docs/meta/todo-ingest.md
+++ b/docs/meta/todo-ingest.md
@@ -50,7 +50,7 @@ If the input is genuinely ambiguous (no clear items can be extracted), the skill
 
 - Resolve `~/.claude/projects/<slug>/todos.json` (Phase 0 of `meta/todo`).
 - Invoke the `Read` tool to read the file fresh per `meta/todo` Phase 0's always-re-read-fresh rule.
-- If the file is missing, lazily create with `{ version: 1, epoch: 0, items: [], archive: [] }` and continue.
+- If the file is missing, lazily create with `{ version: 2, epoch: 0, items: [] }` and continue.
 
 ## Phase 2: Sub-agent parses free-form input
 

--- a/docs/meta/todo-view.md
+++ b/docs/meta/todo-view.md
@@ -27,7 +27,7 @@ This skill replaces Claude Code's in-session TodoWrite list with the cross-sessi
 - `<id>` OR fuzzy text — render just the matching item with full detail in chat (text, group, scope, priority rationale, status, id, ... — internal fields are visible because the user explicitly asked for the record).
 - `--tier P0` / `--tier P1` / etc. — filter to a single tier (internal flag; tier is hidden from output but still usable for filtering).
 - `--group <name>` — filter to a single group.
-- `--all` — include `deferred` and `done`-but-not-yet-archived items in the TodoWrite render.
+- `--all` — include `deferred` and `failed` items in the TodoWrite render (normally deferred items are hidden until due).
 
 ## Phase 1: Read the store — fresh, every time
 
@@ -76,7 +76,6 @@ Only `title` is rendered. `body` (the optional longer description) is reserved f
 | Same format with the leading verb of the item title gerundized when easy (e.g. `[DETRITUS] Implement...` → `[DETRITUS] Implementing...`) | `activeForm` |
 | `status: open` | `"pending"` |
 | `status: in-progress` | `"in_progress"` |
-| `status: done` (only if `--all` was passed) | `"completed"` |
 | `status: deferred` | omitted from the call |
 | `status: failed` | `"pending"` with `content` prefixed by `⚠ FAILED:` |
 
@@ -192,7 +191,7 @@ Any `/todo` invocation against this JSON state MUST produce exactly this TodoWri
 
 ## Phase 5: Single-id / fuzzy-text detail mode
 
-If the user passed `<id>` (e.g. `t_003`) OR a fuzzy text string (e.g. `/todo view "janitor write"`), resolve to the matching item and render its **full record** in chat (not via TodoWrite — this is a debug query, not a list view). Show: id, group, title, body (if present), status, priority {score, tier, rationale}, scope {repos, paths, evidence, concreteness, knownBlockers}, deps, tags, addedAt, editedAt, claimedAt, completedAt, deferredUntil, forkSession.
+If the user passed `<id>` (e.g. `t_003`) OR a fuzzy text string (e.g. `/todo view "janitor write"`), resolve to the matching item and render its **full record** in chat (not via TodoWrite — this is a debug query, not a list view). Show: id, group, title, body (if present), status, priority {score, tier, rationale}, scope {repos, paths, evidence, concreteness, knownBlockers}, deps, tags, addedAt, editedAt, claimedAt, deferredUntil, forkSession.
 
 The `body` field is shown in this detail mode but never in the TodoWrite list view — that's the whole point of the title/body split.
 
@@ -239,8 +238,8 @@ No matching todos. (TodoWrite list cleared.)
 - TodoWrite content shows `[<UPPERCASE-PREFIX>] <item text>` per row (or bare text for ungrouped items). No synthetic header rows, no ids, no scores, no tiers per `meta/todo` convention #11. No markdown syntax (bold, italics, links) — Claude Code's TodoWrite UI renders content as plain text and would show the literal markers.
 - Always call TodoWrite, even when the active list is empty (an empty TodoWrite call clears stale items from the IDE).
 - **The compact prefix is the only place the group appears in the IDE view.** The full group title is reserved for detail-mode (`/todo view <id>`) and for `/todo view --group <full title>` filter input.
-- Don't reveal `archive` items unless `--all` is passed AND the user has explicitly asked for history.
+- There is no `archive` to reveal — completed items are evicted from the store on `/todo-done`, so history lives in the cited PR/issue/git, not here.
 - Don't surface deferred items whose `deferredUntil` is in the future without `--all` — the whole point of defer is to drop the item from view.
-- If the file's `version` doesn't match the skill's expected version (`version: 1`), stop and surface the mismatch to the user — don't render best-effort. A future schema bump would ship its own migration logic; in the meantime, the only valid value is 1.
+- If the file's `version` doesn't match the skill's expected version (`version: 2`), stop and surface the mismatch to the user — don't render best-effort. A v1 store (has an `archive` array or `done` items) should be migrated by the next mutation per `meta/todo` #2 before a clean render.
 - The TodoWrite render REPLACES whatever was previously in the IDE's todo list. Users invoking /todo-view should understand this is a "switch to persistent-todo view" action.
 - Detail-mode (single-id / fuzzy-match) is the one place internal fields surface — the user explicitly asked for the record.

--- a/docs/meta/todo-work.md
+++ b/docs/meta/todo-work.md
@@ -61,7 +61,7 @@ Apply these steps in order to the resolved item. If a step blocks, stop and repo
 
 2. **Sync the branch.** `git checkout <default-branch>` and `git pull --ff-only` so work starts from current head. New branch is cut from the fetched default, never from the current working branch. Branch name derived from the item's `title` (kebab-case, scoped to the change shape — `fix/`, `feat/`, `refactor/`, `docs/`, `chore/` prefix per /gh-issue-work convention).
 
-3. **Verify the issue is real and actionable.** Write a test (or tests) that *fail* against the current code and replicate the reported behavior. Use the item's `scope.evidence` file:line refs as the starting point — drop a breakpoint or failing assertion at the cited location. If the test cannot be made to fail, the item may be stale — stop, report, and offer to mark it `done` (with a "stale-on-arrival" tag) without opening a PR. Don't silently advance on a stale item.
+3. **Verify the issue is real and actionable.** Write a test (or tests) that *fail* against the current code and replicate the reported behavior. Use the item's `scope.evidence` file:line refs as the starting point — drop a breakpoint or failing assertion at the cited location. If the test cannot be made to fail, the item may be stale — stop, report, and offer to evict it via `/todo-done` (no PR) or downgrade it via `/todo-edit`. Don't silently advance on a stale item.
 
    - For async or subscription code, follow `testing/go-backend-async` patterns: precise `wg.Add(N)`, callbacks only update state, no sleeps, no polling.
    - Tests must be fast and low-resource. No long sleeps, no heavyweight load generators, no high goroutine counts unless essential.
@@ -76,7 +76,7 @@ Apply these steps in order to the resolved item. If a step blocks, stop and repo
 
 8. **Open issue + PR via `/gh`**. Let the router dispatch to `gh-issue-create` then `gh-issue-work`. Issue body is product-focused (no code identifiers); PR body describes the final state. The `plane` label is applied automatically by `gh-issue-create`. **Skip this step if `--no-pr` was passed.**
 
-9. **Mark the item done via `/todo-done <id>`.** This is the protocol's terminal step. The item's status flips to `done`, `completedAt` is stamped, the forkSession lock (if any) is cleared, and the next-up survivors are re-ranked per `/todo-done` Phase 3.
+9. **Mark the item done via `/todo-done <id>`.** This is the protocol's terminal step. The item is removed from the store (eviction — no retained `done` status), the forkSession lock (if any) is released with it, and the next-up survivors are re-ranked per `/todo-done` Phase 3.
 
 10. **Hand back to the user.** Stop there. The user reviews the PR and either gives feedback or says "next".
 
@@ -88,7 +88,7 @@ If step 3 cannot produce a failing test, the item was a false positive or has al
 
 - What was tried (the candidate failing-test scenarios).
 - Current code state at the cited `scope.evidence` refs, showing the issue is not present.
-- Recommendation: mark the item `done` with a `stale-on-arrival` tag (via `/todo-done` + `/todo-edit --tag stale-on-arrival`), or downgrade priority via `/todo-edit`.
+- Recommendation: evict it via `/todo-done` (it won't open a PR), or — if you want it to stay visible — downgrade its priority via `/todo-edit`. (A `stale-on-arrival` tag is pointless now: `/todo-done` removes the item, so the tag wouldn't persist.)
 
 Wait for explicit user confirmation before any status mutation. No silent done-flips.
 

--- a/docs/meta/todo.md
+++ b/docs/meta/todo.md
@@ -39,7 +39,7 @@ One entry point for the `/todo-*` skill family. Reads the conversation + any arg
 These apply to every sub-skill this router dispatches to.
 
 1. **Single canonical store: `~/.claude/projects/<slug>/todos.json`.** `<slug>` is the project slug the memory system uses at the same location (e.g. `c--ClintonStuff-github` mirrors the cwd path). One file per project. The JSON is the source of truth; any markdown view is derived.
-2. **Schema**: `{ version: 1, epoch: <int>, updatedAt: <ISO>, items: [...], archive: [...] }`. Each item: `{ id, title, body?, group, status, priority: {score, tier, rationale}, scope: {repos, paths, evidence?, concreteness, knownBlockers}, addedAt, editedAt?, claimedAt?, completedAt, deferredUntil, forkSession, deps, tags, source }`.
+2. **Schema**: `{ version: 2, epoch: <int>, updatedAt: <ISO>, items: [...] }` — there is **no `archive`** array, and items carry no `completedAt`: completed items are *removed* from the store, not retained (see #4). Each item: `{ id, title, body?, group, status, priority: {score, tier, rationale}, scope: {repos, paths, evidence?, concreteness, knownBlockers}, addedAt, editedAt?, claimedAt?, deferredUntil, forkSession, deps, tags, source }`.
 
    **Field semantics**:
    - `title` — short, imperative, one-line summary of the work. Used as the TodoWrite content text. Required.
@@ -49,11 +49,13 @@ These apply to every sub-skill this router dispatches to.
    - `editedAt` (optional) — stamped by /todo-edit on first edit.
    - `claimedAt` (optional) — stamped by /todo-claim when the item goes in-progress.
 
-   The `version` field is a forward-compatibility hook — if a future PR changes the schema shape, that PR bumps the version and ships its own migration logic. There is no migration in this PR; the schema ships at version 1.
+   The `version` field is a forward-compatibility hook — a PR that changes the schema shape bumps the version and ships its own migration logic. The schema ships at **version 2**. The v1→v2 migration runs lazily on the first mutation of an older store: drop the top-level `archive` array, remove every item with `status: done`, strip the now-unused `completedAt` field, and set `version: 2`. A v1 store is detected by the presence of an `archive` key or any `done` item.
 
    See the per-skill docs for which fields each operation touches.
 3. **Atomic, epoch-checked writes.** Every mutating sub-skill reads the file, captures `epoch`, computes the mutation, and writes only if `epoch` is unchanged. Mismatched epoch → another session wrote first → re-read + retry. Prevents two parallel sessions clobbering each other.
-4. **Status values**: `open`, `in-progress`, `done`, `failed`, `deferred`. Lifecycle: open → (claimed by /todo-claim) in-progress → (/todo-done) done → (/todo-clear) moved to archive. `failed` is set when a forked session reports it couldn't complete its assignment. `deferred` is set by /todo-defer with a `deferredUntil` date.
+
+   **Keep the store small; never shell out to write it.** Because completed items are removed (#4, #2), the active store stays small — typically a few dozen items at most. The delegated writer MUST mutate it with the `Write`/`Edit` tools only; it must NOT shell out to a script (`python`, `jq`, `sed`, and especially `PowerShell`) to patch the JSON. A small file is exactly why a wholesale `Write` is reliable. If the file is large enough that scripting the edit feels necessary, that is the signal the store has grown wrong (stale items never evicted) — fix that, don't bypass the tool sandbox. (The one sanctioned exception is a one-time v1→v2 migration of an oversized legacy store, where a `python` filter may be used to produce the small v2 result.)
+4. **Status values**: `open`, `in-progress`, `failed`, `deferred`. Lifecycle: open → (claimed by /todo-claim) in-progress → (/todo-done) **removed from the store**. `done` is a terminal *action*, not a persisted status — `/todo-done` deletes the item's row; the store never accumulates completed work (its record lives in the PR/issue/git the item cited). This keeps the store bounded to the active working set. `failed` is set when a forked session reports it couldn't complete its assignment; `deferred` is set by /todo-defer with a `deferredUntil` date. Both `failed` and `deferred` persist in the store and are pruned manually via `/todo-clear`.
 5. **Priority always carries rationale.** Every item has `priority.score` (0–100), `priority.tier` (P0/P1/P2/P3), and `priority.rationale` (one sentence). Sub-agents that re-rank surface the rationale so the user can override.
 6. **Scope is persistent, not lazy.** Every item carries `scope.concreteness` (`concrete`, `ambiguous`, or `exploratory`) along with its target repos and paths. /todo-add infers and stores; /todo-fork reads stored scope to gate fork eligibility. An item with `concreteness != "concrete"` is automatically ineligible for forking.
 7. **Sub-agent model tiering.** Per convention #13, every `/todo-*` skill (mutations AND reads) delegates its I/O + reasoning work to a sub-agent. The model tier varies by skill: routine mutations and read-only ops (add, done, edit, defer, claim, clear, view, file) use Haiku — these are mechanical schema/render work. Reasoning passes (audit, idle, fork-gating, import-dedup) use Sonnet — these need genuine LLM judgment.
@@ -164,7 +166,7 @@ A SessionStart hook that auto-renders on session open was considered and intenti
 ## Phase 0: Locate the store
 
 - Derive the project slug from cwd (same logic the memory system uses).
-- Resolve `~/.claude/projects/<slug>/todos.json`. If the file doesn't exist yet, the router lazily creates it with `{ version: 1, epoch: 0, items: [], archive: [] }` on the first mutation. Read-only ops on a missing file return "no todos yet" without creating it.
+- Resolve `~/.claude/projects/<slug>/todos.json`. If the file doesn't exist yet, the router lazily creates it with `{ version: 2, epoch: 0, items: [] }` on the first mutation. Read-only ops on a missing file return "no todos yet" without creating it. If an existing store is version 1 (has an `archive` array or `done` items), the first mutation migrates it to version 2 per convention #2.
 - Honor `~/.claude/projects/<slug>/todos.json` over any project-local `.claude/todos.json`. If both exist, prefer the user-scoped store and surface a one-line note to the user.
 
 ### Always re-read fresh — never use cached context
@@ -192,7 +194,7 @@ Apply the first matching rule:
 | `/todo idle` OR "I'm between tasks" / "take a breather" / "let's plan" | `/todo-idle` |
 | `/todo edit <id> <text>` OR "change t_003 to..." / "rename t_001..." | `/todo-edit` |
 | `/todo defer <id> <when>` OR "snooze t_002 tomorrow" / "later t_004" | `/todo-defer` |
-| `/todo clear` OR "archive done" / "clean up completed" | `/todo-clear` |
+| `/todo clear` OR "prune failed/deferred" / "drop stale items" | `/todo-clear` |
 | `/todo file` OR "where is the todo file" / "show the path" | `/todo-file` |
 | `/todo fork` OR "fork these in parallel" / "parallelize my todos" | `/todo-fork` |
 | `/todo claim <id>` OR (inside a forked conversation) "I'm working on t_005" | `/todo-claim` |


### PR DESCRIPTION
## Summary
Closes #68. Makes the `/todo` cross-session store the **working set only**, so it stays bounded.

- `/todo-done` now **removes** the completed item from the store instead of marking it `done`. There is no archive — completion history already lives in the PR/issue/git the item cited.
- Schema bumps to **version 2**: the `archive` array and the per-item `completedAt` field are dropped, with a lazy v1→v2 migration on first mutation (drop `archive`, remove any `done` items, strip `completedAt`).
- `/todo-clear` is repurposed: its archive job is gone, so it now prunes `failed`/`deferred` items the user no longer wants.
- Adds a convention: keep the store small and mutate it with the Write/Edit tools — never shell out to a script to patch the JSON. (On a large store the delegated writer was reaching for a shell, which on Windows meant PowerShell and tripped a command deny-list. Bounding the file removes the incentive entirely.)

## Why
On a real project the store reached 42 items / ~58 KB, ~60% of them already done, because completed items were never evicted (`/todo-clear` in practice never ran). Once the file is that large, the small delegated sub-agent that performs mutations can't rewrite it cleanly and falls back to scripted edits — defeating the tool sandbox. Eviction-on-done keeps the file naturally small and the writes safe.

## Changed
13 `meta/todo*` docs: the schema/lifecycle/migration in `todo`, the eviction behavior in `todo-done`, the repurpose of `todo-clear`, and consistency fixes across `add/edit/file/idle/ingest/view/claim/defer/fork/work` (removing every place that treated `done` as a persisted status or referenced the `archive`).

## Test plan
- [ ] `/todo-done` on an item removes it from the store (no `done` row, no archive)
- [ ] a v1 store (has `archive` or `done` items) migrates to v2 on first mutation
- [ ] `/todo-clear` prunes failed/deferred and never touches open/in-progress
- [ ] no doc still filters or checks for a persisted `done` status

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)