### PR TITLE
chore(release): bump detritus to 3.20.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "detritus",
-    "version": "3.19.0",
+    "version": "3.20.0",
     "description": "Knowledge base plugin for the ooo ecosystem — coding patterns, testing workflows, and library documentation served via MCP tools and agent skills",
     "author": "benitogf",
     "repository": "https://github.com/benitogf/detritus"

--- a/plugins/detritus/.codex-plugin/plugin.json
+++ b/plugins/detritus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",


### PR DESCRIPTION
## detritus 3.20.0

Bumps the version across all three `plugin.json` manifests (`plugin.json`, `.codex-plugin/plugin.json`, `plugins/detritus/.codex-plugin/plugin.json`) from `3.19.0` → `3.20.0`. Merging and tagging `v3.20.0` triggers the release workflow (regenerates the embedded search index via `go generate`, then goreleaser builds and publishes the binaries).

### Changes since v3.19.0

- **#69 docs(todo)** — evict completed items on done instead of archiving, so the todo store stays bounded.
- **#71 docs(smith)** — require every `/smith` loop tick to guarantee the next tick fires, closing the self-continuation stall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)