### PR TITLE
docs: clarify human-facing detritus guide

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,153 @@
+# Detritus Development Notes
+
+This file is for maintainers. Keep `README.md` focused on people who only need
+to install and use Detritus.
+
+## Documentation Boundaries
+
+`README.md` is the public user guide. It should cover:
+
+- The human install prompt: ask an AI coding tool to install the MCP from the
+  GitHub repository.
+- User-facing capabilities and top-level routers.
+- Simple command descriptions that do not require knowing the internal workflow
+  docs.
+
+Shell install commands, update commands, pack CLI commands, raw MCP tool names,
+sub-skill families, schema details, and routing mechanics belong in
+`INSTALL.md`, this file, or the relevant `docs/meta/*` knowledge documents. Do
+not expand `README.md` with implementation entry points.
+
+## Current Implementation Surface
+
+The MCP knowledge tools are registered in `main.go`:
+
+- `kb_list`
+- `kb_get`
+- `kb_search`
+- `kb_sections`
+
+The MCP workspace-pack tools are registered in `internal/code/tools.go`:
+
+- `code_pack`
+- `code_list`
+- `code_tree`
+- `code_search`
+- `code_outline`
+- `code_get`
+
+These MCP tool names are implementation details. README should describe the
+capability ("Detritus guidance", "workspace packs", "/code") rather than naming
+these tools.
+
+## User-Facing Routers
+
+`detritus --setup` generates Codex skills from every Markdown file under
+`docs/`. The public README may name broad user commands that fit the human guide:
+
+- `/code`
+- `/gh`
+- `/todo`
+- `/truthseeker`
+- `/plan`
+- `/testing`
+- `/vibe`
+- `/janitor`
+- `/smith`
+
+Specialist guidance commands are installed, but they should stay out of the
+human README unless the README grows an advanced section:
+
+- `/coding-style`
+- `/go-modern`
+- `/line-of-sight`
+
+The plugin command shims currently bundled in `commands/` and
+`plugins/detritus/commands/` are:
+
+- `/truthseeker`
+- `/plan`
+- `/testing`
+- `/coding-style`
+- `/go-modern`
+- `/line-of-sight`
+- `/vibe`
+- `/janitor`
+- `/smith`
+- `/grow`
+- `/optimize`
+
+`/grow` and `/optimize` are maintainer commands. They are installed so maintainers
+can improve and tune the Detritus knowledge base, but they should not be promoted
+in the README user command table.
+
+## Internal Router Families
+
+`/gh`, `/todo`, and `/code` are user-facing routers. Their routed sub-skills and
+backing MCP tools are not user-facing documentation surface.
+
+README may list:
+
+- `/gh` as the GitHub issue/PR workflow entry point.
+- `/todo` as the persistent todo workflow entry point.
+- `/code` as the workspace-pack entry point.
+
+README should not list `/gh-issue-work`, `/gh-feedback-work`, `/gh-self-review`,
+`/gh-pr`, `/todo-add`, `/todo-work`, `code_search`, `code_get`, or similar
+internal family members as public user commands.
+
+If a future change promotes a sub-skill into a real user command, update both:
+
+- `README.md`, only for the user-facing entry point.
+- This file, with the implementation and routing details.
+
+## Workspace Pack Entry Points
+
+Workspace pack behavior is exposed in three places:
+
+- The `/code` router in `docs/code/code.md`.
+- MCP tools in `internal/code/tools.go`.
+- CLI flags in `main.go`: `--pack`, `--packs`, `--refresh`, and `--unpack`.
+
+README should document `/code` as the user-facing workspace-pack command. Pack
+CLI flags live in `INSTALL.md`; `code_*` MCP tools stay in this maintainer
+document.
+
+## Generated Knowledge Data
+
+`main.go` embeds `docs/` and `generated/data.gob`.
+
+When any file under `docs/` changes, run:
+
+```bash
+go generate ./...
+```
+
+The generator in `cmd/generate/` parses every Markdown file under `docs/`, builds
+the search index, and writes `generated/data.gob`.
+
+Changes to `README.md` or this file do not require regenerating the knowledge
+data because they are not under `docs/`.
+
+## Local Verification
+
+Before sending documentation changes:
+
+```bash
+go test ./...
+```
+
+Before sending knowledge-base changes under `docs/`:
+
+```bash
+go generate ./...
+go test ./...
+```
+
+Before releasing a new binary:
+
+```bash
+go generate ./...
+go test ./...
+go build -o detritus .
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,58 @@
+# Manual Install
+
+This file is for AI tools and maintainers that need explicit shell commands.
+Human users should usually ask their AI coding tool to install Detritus from the
+GitHub repository instead of running these steps themselves.
+
+## Install From Release Scripts
+
+Linux/macOS:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/benitogf/detritus/main/install.sh | bash
+```
+
+Windows PowerShell:
+
+```powershell
+iwr -useb https://raw.githubusercontent.com/benitogf/detritus/main/install.ps1 | iex
+```
+
+The install scripts download the latest release and run:
+
+```bash
+detritus --setup
+```
+
+`detritus --setup` configures detected assistant apps and editors.
+
+## Install From A Downloaded Binary
+
+Download a binary from the
+[latest release](https://github.com/benitogf/detritus/releases/latest), put it on
+`PATH`, then run:
+
+```bash
+detritus --setup
+```
+
+## Update
+
+```bash
+detritus --update
+```
+
+`detritus --update` downloads the latest release and runs setup with the new
+binary.
+
+## Workspace Pack CLI
+
+Most users should use `/code`. These commands are available for tools and
+maintainers that need direct pack management:
+
+```bash
+detritus --pack my-project /absolute/path/to/project
+detritus --packs
+detritus --refresh my-project
+detritus --unpack my-project
+```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,14 @@ detritus --setup
 
 `detritus --setup` configures detected assistant apps and editors.
 
+## Add The Codex Plugin Marketplace
+
+For Codex plugin workflows, add the Detritus plugin marketplace/source:
+
+```bash
+codex plugin marketplace add benitogf/detritus
+```
+
 ## Install From A Downloaded Binary
 
 Download a binary from the

--- a/README.md
+++ b/README.md
@@ -1,124 +1,42 @@
 # detritus
 
-MCP knowledge base server. Exposes coding knowledge as MCP tools for AI assistants across VS Code, Windsurf, Cursor, Claude Code, and Verdent.
+Detritus is an MCP knowledge base for AI coding assistants. It gives the
+assistant reusable guidance for planning, testing, GitHub work, project todos,
+and codebase exploration.
 
 ## Install
 
-**Codex plugin:**
-```bash
-codex plugin marketplace add benitogf/detritus
+Ask your AI coding tool to install Detritus from this repository:
+
+```text
+please install detritus mcp https://github.com/benitogf/detritus
 ```
 
-The plugin manifest lives at `.codex-plugin/plugin.json`; the bundled MCP
-launcher downloads the latest release binary into a local cache on first use,
-then starts the server.
+Or, if your tool supports Markdown links:
 
-**Linux / macOS / Git Bash:**
-```bash
-curl -sSL https://raw.githubusercontent.com/benitogf/detritus/main/install.sh | sh
+```text
+please install detritus mcp [benitogf/detritus](https://github.com/benitogf/detritus)
 ```
 
-**Windows PowerShell:**
-```powershell
-irm https://raw.githubusercontent.com/benitogf/detritus/main/install.ps1 | iex
-```
+That is the human install path. You should not need to run Detritus as a CLI
+tool yourself. Manual install details for an assistant or maintainer live in
+[INSTALL.md](./INSTALL.md).
 
-Or download from [Releases](https://github.com/benitogf/detritus/releases), place in PATH, then:
+## Commands
 
-```bash
-detritus --setup
-```
+Use Detritus by command name:
 
-## MCP Tools
+| Command | Use it for |
+| --- | --- |
+| `/plan` | Turn a request into an implementation plan. |
+| `/testing` | Choose a testing approach for a feature, bug, or risk. |
+| `/truthseeker` | Check claims and assumptions against evidence. |
+| `/code` | Use a workspace code index for codebase questions or scoped changes. |
+| `/gh` | Work with GitHub issues and pull requests. |
+| `/todo` | Manage a persistent project todo list across sessions. |
+| `/vibe` | Start from a plain-language product request and drive delivery. |
+| `/janitor` | Run recurring maintenance on a project. |
+| `/smith` | Run the build loop for a scoped feature. |
 
-| Tool | Description |
-|------|-------------|
-| `kb_list` | List all documents with descriptions |
-| `kb_get` | Get document by name (optional `section` param) |
-| `kb_search` | Full-text search across all documents |
-| `kb_sections` | List sections in a document |
-
-## Slash Commands
-
-| Command | Doc |
-|---------|-----|
-| `/truthseeker` | Evidence-based reasoning |
-| `/plan` | Requirements analysis |
-| `/testing` | Testing decision table |
-| `/grow` | KB improvement from corrections |
-| `/optimize` | KB retrieval optimization |
-| `/janitor` | Recurring safe codebase maintenance |
-| `/smith` | Feature loop — `/plan` gate, then build until merged, then audit the changed code |
-| `/coding-style` | Naming, error handling, commits |
-| `/go-modern` | Modern Go idioms (1.22+) |
-| `/line-of-sight` | Flat code, early returns |
-
-Codex displays plugin commands with the plugin namespace, for example
-`/detritus:plan`.
-
-### GitHub workflow family
-
-The `gh-*` skills are a coordinated set dispatched by the `/gh` router. The router classifies the input (URL, ref, or free text) and hands off to one of the sub-skills.
-
-| Command | Doc |
-|---------|-----|
-| `/gh` | Router for the family — picks a sub-skill from context |
-| `/gh-issue-create` | Draft a GitHub issue from conversation, post with attribution footer |
-| `/gh-issue-work` | Take an issue end-to-end: branch, fix, test, commit, push, self-review, open PR |
-| `/gh-feedback-work` | Address open review feedback on a PR; updates PR body in place, never posts comments |
-| `/gh-self-review` | Pre-flight self-audit of pending local changes — **delegated to a fresh sub-agent** so the review runs without the conversational context that produced the code |
-| `/gh-pr` | Hard-review someone else's PR; posts an APPROVE or REQUEST_CHANGES review via `gh api` |
-
-Two patterns hold the family together:
-
-- **`meta/review-rigor`** (category: `principles`, do-not-invoke-directly) is the shared analysis checklist that both `/gh-pr` and `/gh-self-review` follow. Tightening the review bar happens in one place; both skills inherit. Treat it like `truthseeker` — loaded by other skills via `kb_get`, never a standalone slash command.
-- **Fresh-agent delegation in `/gh-self-review`**: the wrapping skill collects scope + diff + intent signals, then spawns a sub-agent via the `Agent` tool to do the actual review. The sub-agent has no prior conversation context, so the audit isn't biased by the discussion that produced the code. This doesn't eliminate the shared-training blind spot, but eliminates the conversational bias — the largest source of self-review false negatives.
-
-### Loop family — recurring work against your workspace
-
-Two recurring-loop commands share the same scheduling, durability, and state mechanics, separated by intent:
-
-| Command | Doc | Intent |
-|---------|-----|--------|
-| `/janitor` | `meta/janitor` | Preserve behavior. Recurring safe audits + small fixes against the codebase |
-| `/smith` | `meta/smith` | Add behavior. `/plan` gate to settle scope, then build until merged, then transition into a janitor-style audit phase on the changed code |
-
-Both run against the actual workspace or repo the user is in — Desktop Routines or an external scheduler (cron, launchd, systemd, Task Scheduler) by default on Claude Code, with equivalent local-checkout schedulers on other platforms. A gitignored scratchpad (`.janitor/<slug>.md` or `.smith/<slug>.md`) carries plan-state across cold ticks. Opt-in GitHub-state-only modes (Cloud Routines, Codex `worktree`, GitHub Actions) exist for maintaining a remote repo without a local checkout.
-
-The shared mechanics live in `meta/loop-core` (do-not-invoke-directly): scratchpad layout, durability rule, audit-to-verify cadence, truthseeker pause on user critique, honest regression reporting, skip-streak guardrail (default eight ticks or two hours of idle wakes), mid-loop pivot via scratchpad orientation, `/gh` delivery routing. Each command references it instead of restating; tightening any shared rule happens in one place.
-
-Example invocations:
-
-```
-/janitor                                                # whole-repo maintenance, default rubric
-/janitor flaky tests                                    # topic-focused maintenance
-/janitor get test wall time under 145s                  # maintenance with a measurable goal
-/janitor weeknights                                     # perpetual living-maintenance; skip-streak guardrail catches drift
-/smith add typed cancellation to subscribe-list         # feature loop; first tick is /plan
-/smith add SSE fallback to the live worker overnight    # feature loop with cadence hint
-```
-
-Mid-loop pivots are handled in chat — saying *"please nudge the loop to focus on perf only"* updates the scratchpad's *Current orientation* field (after a truthseeker pause) and the next tick honors the new focus without re-invocation. The same pattern works for both commands. Adapter-specific scheduling lives in `meta/janitor-platforms`.
-
-## Update
-
-```bash
-detritus --update
-```
-
-Or, from an AI assistant with detritus skills installed, invoke `/detritus-update`.
-
-## Development
-
-```bash
-go generate ./...   # rebuild index
-go test ./...
-go build -o detritus .
-```
-
-Push a tag to release:
-
-```bash
-git tag v3.1.0
-git push origin v3.1.0
-```
+The command names are the user surface. Internal tools, routed subcommands, and
+maintainer details are intentionally left out of this README.


### PR DESCRIPTION
## Summary
Closes #74 - Detritus now presents a clearer human-facing guide.

- The public guide now starts with the human install prompt and the broad command surface.
- Manual install, update, pack, and Codex marketplace setup details are separated for tools and maintainers.
- Internal routing and tool inventory details are documented outside the public guide.

## Test plan
- [x] Public guide scan excludes manual shell install/update commands, internal tool names, routed subcommands, maintainer commands, and specialist guidance commands.
- [x] `go test ./internal/...`
- [ ] `go test ./...` currently fails on an existing Windows todo-guard path expectation unrelated to this docs change.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)