### PR TITLE
chore(release): bump detritus to 3.21.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "detritus",
-    "version": "3.20.0",
+    "version": "3.21.0",
     "description": "Knowledge base plugin for the ooo ecosystem — coding patterns, testing workflows, and library documentation served via MCP tools and agent skills",
     "author": "benitogf",
     "repository": "https://github.com/benitogf/detritus"

--- a/plugins/detritus/.codex-plugin/plugin.json
+++ b/plugins/detritus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",


### PR DESCRIPTION
Releases the changes accumulated since v3.20.0:

- #72: docs(janitor) — add usage-limit resilience and an in-session durable cron adapter so loops survive interruptions.
- #75: docs — clarify the human-facing detritus guide and preserve the codex marketplace install note.
- #77: refactor(meta) — consolidate the /todo family from 15 docs to 4.

Bumps the version in all three plugin manifests (`plugin.json`, `.codex-plugin/plugin.json`, `plugins/detritus/.codex-plugin/plugin.json`). Tagging `v3.21.0` after merge triggers the goreleaser workflow, which regenerates the embedded search index (`go generate`) and publishes binaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)