### PR TITLE
chore(release): bump detritus to 3.22.0

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",

--- a/plugin.json
+++ b/plugin.json
@@ -1,6 +1,6 @@
 {
     "name": "detritus",
-    "version": "3.21.0",
+    "version": "3.22.0",
     "description": "Knowledge base plugin for the ooo ecosystem — coding patterns, testing workflows, and library documentation served via MCP tools and agent skills",
     "author": "benitogf",
     "repository": "https://github.com/benitogf/detritus"

--- a/plugins/detritus/.codex-plugin/plugin.json
+++ b/plugins/detritus/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "detritus",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Knowledge base MCP server for coding patterns, testing workflows, Go guidance, and ooo ecosystem documentation.",
   "author": {
     "name": "benitogf",


### PR DESCRIPTION
Release v3.22.0, bumping the three `plugin.json` version fields from 3.21.0.

Changes accumulated since v3.21.0:

- #80: docs(vibe) — clarify the autonomous feature contract.
- #83: feat(meta) — extract `/vibe-plan` from `/vibe` and compose them.
- #82: feat(testing) — add the flaky-check command with manual batch handling.

Tagging `v3.22.0` after merge triggers the release workflow, which regenerates the embedded search index (`go generate`) and builds the cross-platform binaries via GoReleaser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)