### PR TITLE
fix(setup): unregister stale candyland MCP entries (self-heal)

### DIFF
--- a/main.go
+++ b/main.go
@@ -413,6 +413,41 @@ func upsertMCPServer(file, parentKey, name, command string, args []any) {
 	fmt.Printf("Updated %s in %s\n", name, file)
 }
 
+// removeMCPServer deletes a named stdio MCP server from file under parentKey,
+// preserving every other server. It is a no-op (and never creates the file) when
+// the file is missing/empty/unparseable, the parent key is absent, or the named
+// entry isn't present — so it never reformat-thrashes a config with nothing to remove.
+func removeMCPServer(file, parentKey, name string) {
+	raw, err := os.ReadFile(file)
+	if err != nil || len(raw) == 0 {
+		return
+	}
+	data := map[string]any{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return
+	}
+	parent, ok := data[parentKey].(map[string]any)
+	if !ok {
+		return
+	}
+	if _, present := parent[name]; !present {
+		return
+	}
+	delete(parent, name)
+	data[parentKey] = parent
+
+	out, err := json.MarshalIndent(data, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal JSON: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(file, append(out, '\n'), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write %s: %v\n", file, err)
+		os.Exit(1)
+	}
+	fmt.Printf("Removed stale %s from %s\n", name, file)
+}
+
 // upsertVSCodeSettings reads a VS Code settings.json and sets the
 // chat.promptFilesLocations, chat.instructionsFilesLocations, and
 // chat.agentFilesLocations keys. Creates the file if it doesn't exist.

--- a/setup.go
+++ b/setup.go
@@ -111,6 +111,7 @@ func setupWindsurf(home, binaryPath string, _ []docEntry, dryRun bool) {
 		return
 	}
 	upsertMCP(cfgFile, "mcpServers", binaryPath)
+	removeMCPServer(cfgFile, "mcpServers", "candyland")
 }
 
 // ---- VS Code ----------------------------------------------------------------
@@ -141,9 +142,11 @@ func setupVSCode(home, binaryPath string, docs []docEntry, dryRun bool) {
 		}
 		if dryRun {
 			fmt.Printf("[dry-run] Would upsert detritus into %s/mcp.json (servers)\n", dir)
+			fmt.Printf("[dry-run] Would remove stale candyland MCP entry from %s/mcp.json\n", dir)
 			fmt.Printf("[dry-run] Would upsert VS Code settings in %s/settings.json\n", dir)
 		} else {
 			upsertMCP(filepath.Join(dir, "mcp.json"), "servers", binaryPath)
+			removeMCPServer(filepath.Join(dir, "mcp.json"), "servers", "candyland")
 			upsertVSCodeSettings(filepath.Join(dir, "settings.json"))
 			cleanOldUserPrompts(filepath.Join(dir, "prompts"))
 		}
@@ -333,8 +336,10 @@ func setupCursor(home, binaryPath string, dryRun bool) {
 		cfgFile := filepath.Join(dir, "mcp.json")
 		if dryRun {
 			fmt.Printf("[dry-run] Would upsert detritus into %s (mcpServers)\n", cfgFile)
+			fmt.Printf("[dry-run] Would remove stale candyland MCP entry from %s\n", cfgFile)
 		} else {
 			upsertMCP(cfgFile, "mcpServers", binaryPath)
+			removeMCPServer(cfgFile, "mcpServers", "candyland")
 			fmt.Printf("Cursor MCP config: %s\n", cfgFile)
 		}
 	}
@@ -346,11 +351,13 @@ func setupClaudeCode(home, binaryPath string, docs []docEntry, dryRun bool) {
 	cfgFile := filepath.Join(home, ".claude.json")
 	if dryRun {
 		fmt.Printf("[dry-run] Would upsert detritus into %s (mcpServers)\n", cfgFile)
+		fmt.Printf("[dry-run] Would remove stale candyland MCP entry from %s\n", cfgFile)
 		fmt.Printf("[dry-run] Would write %d skill files to %s\n", len(docs), filepath.Join(home, ".claude", "skills"))
 		setupClaudeTodoGuard(home, binaryPath, hasTodoDoc(docs), true)
 		return
 	}
 	upsertMCP(cfgFile, "mcpServers", binaryPath)
+	removeMCPServer(cfgFile, "mcpServers", "candyland")
 	fmt.Printf("Claude Code MCP config: %s\n", cfgFile)
 
 	generateClaudeSkills(home, docs)
@@ -414,6 +421,7 @@ func setupCodex(home, binaryPath string, docs []docEntry, dryRun bool) {
 	configFile := filepath.Join(codexDir, "config.toml")
 	if dryRun {
 		fmt.Printf("[dry-run] Would upsert detritus into %s (mcp_servers)\n", configFile)
+		fmt.Printf("[dry-run] Would remove stale candyland MCP entry from %s\n", configFile)
 		fmt.Printf("[dry-run] Would write %d Codex skill files to %s\n", len(docs), skillsDir)
 		return
 	}
@@ -434,6 +442,13 @@ func upsertCodexMCPConfig(file, command string) {
 		"command = " + tomlString(command),
 		"args = []",
 	})
+
+	// Self-heal: drop any stale candyland MCP table. candyland no longer ships a
+	// control-mcp subcommand, so a registered entry boots its full app and fails
+	// the MCP handshake. Only strip if the file already exists (don't create it).
+	if fileExists(file) {
+		content = removeTOMLTable(content, "mcp_servers.candyland")
+	}
 
 	if err := os.MkdirAll(filepath.Dir(file), 0o755); err != nil {
 		fmt.Fprintf(os.Stderr, "failed to create Codex config directory: %v\n", err)
@@ -471,6 +486,33 @@ func upsertTOMLTable(content, table string, body []string) string {
 		return block + "\n"
 	}
 	return content + "\n\n" + block + "\n"
+}
+
+// removeTOMLTable strips a full [table] block (its header plus all body lines up
+// to the next "[" header or EOF) from content, preserving every other table. It is
+// a no-op when the table isn't present.
+func removeTOMLTable(content, table string) string {
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	header := "[" + table + "]"
+	lines := strings.Split(normalized, "\n")
+	filtered := make([]string, 0, len(lines))
+	removed := false
+
+	for i := 0; i < len(lines); i++ {
+		if strings.TrimSpace(lines[i]) == header {
+			removed = true
+			for i+1 < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i+1]), "[") {
+				i++
+			}
+			continue
+		}
+		filtered = append(filtered, lines[i])
+	}
+
+	if !removed {
+		return content
+	}
+	return strings.TrimRight(strings.Join(filtered, "\n"), "\n") + "\n"
 }
 
 func removeTOMLTableForms(lines []string, table string) ([]string, int) {
@@ -723,6 +765,7 @@ func setupVerdent(home, binaryPath string, docs []docEntry, dryRun bool) {
 
 	if dryRun {
 		fmt.Printf("[dry-run] Would upsert detritus into %s (mcpServers)\n", mcpFile)
+		fmt.Printf("[dry-run] Would remove stale candyland MCP entry from %s\n", mcpFile)
 		fmt.Printf("[dry-run] Would upsert DETRITUS-RULES block in %s\n", rulesFile)
 		fmt.Printf("[dry-run] Would write %d skill files to %s\n", len(docs), skillsDir)
 		return
@@ -735,6 +778,7 @@ func setupVerdent(home, binaryPath string, docs []docEntry, dryRun bool) {
 
 	// MCP config
 	upsertMCPJSON(mcpFile, "mcpServers", binaryPath)
+	removeMCPServer(mcpFile, "mcpServers", "candyland")
 
 	// VERDENT.md rules block
 	upsertVerdentRules(rulesFile, docs)

--- a/setup_test.go
+++ b/setup_test.go
@@ -45,6 +45,125 @@ func TestSetupDoesNotRegisterCandylandMCP(t *testing.T) {
 	}
 }
 
+// TestRemoveMCPServerStripsStaleCandyland verifies that removeMCPServer deletes a
+// stale candyland entry while leaving detritus and any other server untouched.
+func TestRemoveMCPServerStripsStaleCandyland(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), ".claude.json")
+	seed := map[string]any{
+		"mcpServers": map[string]any{
+			"detritus":  map[string]any{"command": "/bin/detritus", "args": []any{}},
+			"candyland": map[string]any{"command": "/bin/candyland", "args": []any{"control-mcp"}},
+			"other":     map[string]any{"command": "/bin/other", "args": []any{}},
+		},
+		"otherTopLevel": "keep-me",
+	}
+	raw, _ := json.MarshalIndent(seed, "", "  ")
+	if err := os.WriteFile(cfg, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	removeMCPServer(cfg, "mcpServers", "candyland")
+
+	got, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read %s: %v", cfg, err)
+	}
+	var data map[string]any
+	if err := json.Unmarshal(got, &data); err != nil {
+		t.Fatalf("parse %s: %v", cfg, err)
+	}
+	s, _ := data["mcpServers"].(map[string]any)
+	if _, present := s["candyland"]; present {
+		t.Error("stale candyland entry must be removed")
+	}
+	if s["detritus"] == nil {
+		t.Error("detritus entry must be preserved")
+	}
+	if s["other"] == nil {
+		t.Error("unrelated server must be preserved")
+	}
+	if data["otherTopLevel"] != "keep-me" {
+		t.Error("unrelated top-level keys must be preserved")
+	}
+}
+
+// TestRemoveMCPServerNoCandylandIsNoOp verifies that removeMCPServer leaves a
+// config without a candyland entry byte-for-byte unchanged (no reformat thrash).
+func TestRemoveMCPServerNoCandylandIsNoOp(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), ".claude.json")
+	original := []byte("{\n  \"mcpServers\": {\n    \"detritus\": {\"command\": \"/bin/detritus\"}\n  }\n}\n")
+	if err := os.WriteFile(cfg, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	before, err := os.Stat(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	removeMCPServer(cfg, "mcpServers", "candyland")
+
+	got, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read %s: %v", cfg, err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("file with no candyland entry must be untouched\nwant: %q\ngot:  %q", original, got)
+	}
+	after, err := os.Stat(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Error("no-op must not rewrite the file (modtime changed)")
+	}
+}
+
+// TestRemoveMCPServerMissingFileIsNoOp verifies removeMCPServer does not create a
+// file that doesn't exist.
+func TestRemoveMCPServerMissingFileIsNoOp(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "absent.json")
+	removeMCPServer(cfg, "mcpServers", "candyland")
+	if _, err := os.Stat(cfg); !os.IsNotExist(err) {
+		t.Errorf("removeMCPServer must not create a missing file, stat err: %v", err)
+	}
+}
+
+// TestRemoveTOMLTableStripsStaleCandyland verifies the codex TOML remover strips
+// the [mcp_servers.candyland] block while keeping [mcp_servers.detritus].
+func TestRemoveTOMLTableStripsStaleCandyland(t *testing.T) {
+	input := strings.Join([]string{
+		"[mcp_servers.candyland]",
+		`command = "/bin/candyland"`,
+		`args = ["control-mcp"]`,
+		"",
+		"[mcp_servers.detritus]",
+		`command = "/bin/detritus"`,
+		"args = []",
+		"",
+	}, "\n")
+
+	got := removeTOMLTable(input, "mcp_servers.candyland")
+
+	if strings.Contains(got, "candyland") {
+		t.Errorf("candyland table must be stripped, got:\n%s", got)
+	}
+	if !strings.Contains(got, "[mcp_servers.detritus]") {
+		t.Errorf("detritus table must be preserved, got:\n%s", got)
+	}
+	if !strings.Contains(got, "/bin/detritus") {
+		t.Errorf("detritus body must be preserved, got:\n%s", got)
+	}
+}
+
+// TestRemoveTOMLTableNoTableIsNoOp verifies removeTOMLTable returns the content
+// unchanged when the table isn't present.
+func TestRemoveTOMLTableNoTableIsNoOp(t *testing.T) {
+	input := "[mcp_servers.detritus]\ncommand = \"/bin/detritus\"\nargs = []\n"
+	if got := removeTOMLTable(input, "mcp_servers.candyland"); got != input {
+		t.Errorf("absent table must be a no-op\nwant: %q\ngot:  %q", input, got)
+	}
+}
+
 // TestGenerateClaudeSkillsPrunesStale verifies that a detritus-generated skill
 // whose backing doc was removed gets pruned on the next setup, while a
 // hand-authored skill (no detritus marker) is left untouched and current docs


### PR DESCRIPTION
A prior detritus registered candyland as an MCP (`candyland control-mcp`). The 0.1 cutover stopped registering it but never removed entries already on disk — and v0.4.x candyland has no `control-mcp` subcommand, so each new session spawned it, it booted the full app instead of an MCP stdio server, the handshake failed, and the host killed it (an unexpected candyland launch that closes itself).

`--setup`/`--update` now actively remove any stale `candyland` MCP entry from every host config detritus manages (Windsurf/VS Code/Cursor/Claude Code/Verdent JSON via `removeMCPServer`; Codex TOML via `removeTOMLTable`), with the dry-run path honored. Strict no-op when nothing to strip (never creates/reformats a clean file; never touches the detritus entry or other servers). The project-scope bootstrapper (`.mcp.json` / `scripts/detritus-mcp.js`) is intentional and left untouched. Tests cover JSON+TOML strip, no-op-when-absent, and missing-file.

Verified: `go build/test/vet` + `GOOS=windows go build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)