### PR TITLE
detritus: enumerate origin session MCP servers and pass them to candyland at launch

### DIFF
--- a/candyland_client.go
+++ b/candyland_client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -497,6 +498,15 @@ func ensureCandylandUp(detritusPath string) error {
 		selfExe = detritusPath
 	}
 	cmd.Env = append(os.Environ(), "DETRITUS_BIN="+selfExe)
+	// Enumerate the origin Claude session's OTHER MCP servers (obsidian, project
+	// tools, etc.) from ~/.claude.json and propagate them as DETRITUS_ORIGIN_MCP
+	// so candyland can graft the SAME tool surface into each spawned agent's
+	// --mcp-config. Best-effort: a missing/unreadable config just means no extra
+	// servers to inherit, never a failed launch. detritus/candyland are dropped —
+	// detritus rides via DETRITUS_BIN above, and candyland is never a child server.
+	if cfg := originMCPConfigJSON(readOriginMCPServers(originClaudeConfigPath(), originCWD())); cfg != "" {
+		cmd.Env = append(cmd.Env, detritusOriginMCPEnv+"="+cfg)
+	}
 	detachProcess(cmd)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start candyland (%s): %w", bin, err)
@@ -512,6 +522,103 @@ func ensureCandylandUp(detritusPath string) error {
 		time.Sleep(250 * time.Millisecond)
 	}
 	return fmt.Errorf("candyland did not become healthy within 20s after start")
+}
+
+// detritusOriginMCPEnv is the env var carrying the origin session's inherited
+// MCP servers to candyland, as an --mcp-config-shaped JSON object
+// ({"mcpServers": {...}}). Empty/absent means nothing extra to inherit.
+const detritusOriginMCPEnv = "DETRITUS_ORIGIN_MCP"
+
+// originMCPExcluded are server names never propagated as inherited servers.
+// detritus rides via DETRITUS_BIN (candyland registers it passively) and
+// candyland is deliberately never registered as a child MCP (see setup.go), so
+// re-inheriting either would double-register or recurse.
+var originMCPExcluded = map[string]bool{"detritus": true, "candyland": true}
+
+// originClaudeConfigPath is the origin Claude session's config file
+// (~/.claude.json), where its MCP servers are registered. Returns "" when the
+// home directory can't be resolved, which readOriginMCPServers degrades to "no
+// servers to inherit".
+func originClaudeConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".claude.json")
+}
+
+// originCWD is the current working directory used to resolve the project-scoped
+// MCP servers, or "" when it can't be determined (only the global servers apply).
+func originCWD() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return cwd
+}
+
+// readOriginMCPServers reads claudeConfigPath and returns the origin session's
+// MCP servers for cwd (mcpServersFromConfig). It is best-effort: a
+// missing/empty/unparseable config or empty path yields an empty map (nothing to
+// inherit), never an error — inheriting the tool surface must never fail a launch.
+func readOriginMCPServers(claudeConfigPath, cwd string) map[string]any {
+	if claudeConfigPath == "" {
+		return map[string]any{}
+	}
+	raw, err := os.ReadFile(claudeConfigPath)
+	if err != nil || len(raw) == 0 {
+		return map[string]any{}
+	}
+	data := map[string]any{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return map[string]any{}
+	}
+	return mcpServersFromConfig(data, cwd)
+}
+
+// mcpServersFromConfig extracts the inheritable MCP servers from a parsed
+// ~/.claude.json: the global "mcpServers" map merged with the project-scoped map
+// for cwd ("projects".<cwd>."mcpServers"), the project scope winning on key
+// collisions (it is the more specific one the origin session actually loaded).
+// Servers in originMCPExcluded are dropped. Pure (parsed config + cwd in → map
+// out) so the merge/exclusion is separately testable.
+func mcpServersFromConfig(data map[string]any, cwd string) map[string]any {
+	out := map[string]any{}
+	merge := func(m map[string]any) {
+		for name, spec := range m {
+			if originMCPExcluded[name] {
+				continue
+			}
+			out[name] = spec
+		}
+	}
+	if global, ok := data["mcpServers"].(map[string]any); ok {
+		merge(global)
+	}
+	if cwd != "" {
+		if projects, ok := data["projects"].(map[string]any); ok {
+			if project, ok := projects[cwd].(map[string]any); ok {
+				if scoped, ok := project["mcpServers"].(map[string]any); ok {
+					merge(scoped)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// originMCPConfigJSON serializes servers as an --mcp-config-shaped JSON object
+// ({"mcpServers": {...}}) for propagation via DETRITUS_ORIGIN_MCP, or "" when
+// there are no servers to inherit (so the caller omits the env var entirely).
+func originMCPConfigJSON(servers map[string]any) string {
+	if len(servers) == 0 {
+		return ""
+	}
+	out, err := json.Marshal(map[string]any{"mcpServers": servers})
+	if err != nil {
+		return ""
+	}
+	return string(out)
 }
 
 // candylandHealthy reports whether the sidecar answers GET /api/health with 200.

--- a/candyland_client_test.go
+++ b/candyland_client_test.go
@@ -337,6 +337,106 @@ func TestReadCampaignRunArgs(t *testing.T) {
 	}
 }
 
+// mcpServersFromConfig merges the global mcpServers with the project-scoped map
+// for cwd (project winning on collisions) and drops detritus/candyland.
+func TestMCPServersFromConfig(t *testing.T) {
+	data := map[string]any{
+		"mcpServers": map[string]any{
+			"detritus":  map[string]any{"command": "detritus"},
+			"candyland": map[string]any{"command": "candyland"},
+			"obsidian":  map[string]any{"command": "obsidian", "args": []any{"--global"}},
+			"shared":    map[string]any{"command": "global-shared"},
+		},
+		"projects": map[string]any{
+			"/work/repo": map[string]any{
+				"mcpServers": map[string]any{
+					"projtool": map[string]any{"command": "projtool"},
+					"shared":   map[string]any{"command": "project-shared"},
+				},
+			},
+			"/other": map[string]any{
+				"mcpServers": map[string]any{"nope": map[string]any{"command": "nope"}},
+			},
+		},
+	}
+
+	got := mcpServersFromConfig(data, "/work/repo")
+
+	if _, has := got["detritus"]; has {
+		t.Error("detritus must be excluded from inherited servers")
+	}
+	if _, has := got["candyland"]; has {
+		t.Error("candyland must be excluded from inherited servers")
+	}
+	if _, has := got["nope"]; has {
+		t.Error("a different project's servers must not leak in")
+	}
+	if _, has := got["obsidian"]; !has {
+		t.Error("global obsidian server should be inherited")
+	}
+	if _, has := got["projtool"]; !has {
+		t.Error("project-scoped server should be inherited")
+	}
+	shared, _ := got["shared"].(map[string]any)
+	if shared["command"] != "project-shared" {
+		t.Errorf("project scope should win on key collision: shared.command = %v, want project-shared", shared["command"])
+	}
+}
+
+// readOriginMCPServers degrades to an empty map (never errors) for a missing
+// path, an empty path, or unparseable JSON — inheriting must never fail a launch.
+func TestReadOriginMCPServers(t *testing.T) {
+	if got := readOriginMCPServers("", "/work/repo"); len(got) != 0 {
+		t.Errorf("empty path should yield no servers, got %v", got)
+	}
+
+	dir := t.TempDir()
+	if got := readOriginMCPServers(filepath.Join(dir, "nope.json"), "/work/repo"); len(got) != 0 {
+		t.Errorf("missing file should yield no servers, got %v", got)
+	}
+
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readOriginMCPServers(bad, "/work/repo"); len(got) != 0 {
+		t.Errorf("unparseable config should yield no servers, got %v", got)
+	}
+
+	good := filepath.Join(dir, "claude.json")
+	if err := os.WriteFile(good, []byte(`{"mcpServers":{"obsidian":{"command":"obsidian"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readOriginMCPServers(good, "/work/repo")
+	if _, has := got["obsidian"]; !has {
+		t.Errorf("obsidian server should be read from config, got %v", got)
+	}
+}
+
+// originMCPConfigJSON emits an --mcp-config-shaped object for non-empty servers
+// and "" when there is nothing to inherit.
+func TestOriginMCPConfigJSON(t *testing.T) {
+	if got := originMCPConfigJSON(map[string]any{}); got != "" {
+		t.Errorf("no servers should yield empty string, got %q", got)
+	}
+	if got := originMCPConfigJSON(nil); got != "" {
+		t.Errorf("nil servers should yield empty string, got %q", got)
+	}
+
+	out := originMCPConfigJSON(map[string]any{"obsidian": map[string]any{"command": "obsidian"}})
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+	servers, ok := parsed["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("output missing mcpServers key: %v", parsed)
+	}
+	if _, has := servers["obsidian"]; !has {
+		t.Errorf("mcpServers should contain obsidian, got %v", servers)
+	}
+}
+
 // ensureCandylandUp returns nil immediately when the health endpoint already
 // answers 200 — no binary needed.
 func TestEnsureCandylandUpAlreadyHealthy(t *testing.T) {


### PR DESCRIPTION
Delivered by a candyland run.

## Request

detritus: enumerate origin session MCP servers and pass them to candyland at launch

Why: ensureCandylandUp (candyland_client.go:489) spawns candyland with only DETRITUS_BIN in env; detritus already reads ~/.claude.json mcpServers (setup.go:364) so it can dynamically enumerate the origin set and propagate it (e.g. CANDYLAND_INHERITED_MCP env) with no hardcoded list, per the north star

This is one work item of the quest: # Objective: candyland agents inherit the origin session's MCP servers

## North star
A developer running candyland must get the **same MCP capabilities their VSCode
Claude session has**. Whatever MCP servers are configured/available in the origin
(VSCode) Claude session — which differ from dev to dev — must be available to the
agents candyland spawns. Nothing about the inherited set may be hardcoded.

## The problem today
Candyland spawns each agent (tech-lead / coders / quest lead / reviewers) as a
headless `claude -p ... --mcp-config <file>` process. That per-agent config
(`internal/conductor/coordinator.go` `busMCPConfig`) contains ONLY:
  - `candyland-comms` (HTTP, the ooo coordination bus)
  - `detritus` (stdio, for kb_*/code_*/skill_* — the Composition Constraint)
The developer's own MCP servers (their VSCode session's servers — user
`~/.claude.json`, project `.mcp.json`, and any VSCode-managed set) are NOT
deliberately propagated. So an agent cannot use the MCPs the dev relies on, and
candyland does not match the dev's VSCode capabilities.

## What "done" looks like
- Agents candyland spawns have access to the full set of MCP servers available in
  the origin session, in ADDITION to the candyland-comms + detritus servers they
  already get (which must keep working).
- The inherited set is discovered dynamically at launch — never a hardcoded list.
  Two devs with different MCP setups each get their own set with no code change.
- Behavior is verified by actually observing an inherited MCP tool being reachable
  from a spawned agent, not merely by asserting a config file was written.

## Likely architecture (the quest confirms/refines — do not treat as fixed)
- **detritus** is itself the MCP server the VSCode session connects to and the
  launcher that starts the candyland sidecar. It is uniquely positioned to
  enumerate the origin session's MCP configuration and hand it to candyland at
  launch (e.g. via env/handshake), rather than candyland guessing. This is the
  probable detritus-side PR.
- **candyland** merges that inherited set into each per-agent `--mcp-config` it
  writes (preserving candyland-comms + detritus), being careful about claude's
  merge-vs-strict semantics and about secrets/env propagation. This is the
  probable candyland-side PR.
- Investigate whether claude already merges the user's configured MCP servers when
  `--mcp-config` is passed WITHOUT `--strict-mcp-config`, and whether the headless
  candyland process runs with the HOME/cwd that makes those config files reachable
  — the real fix may be as much about reachability as about copying a list.

## Scope
- `github.com/benitogf/candyland`
- `github.com/benitogf/detritus`
Open one PR per repo that receives changes. Both are public benitogf repos — never
leak any idx product/customer/device names into code, commits, issues, or PRs.

## Safety boundary
- Discover the inherited MCP set dynamically; no hardcoded server lists.
- Do not weaken existing coordination-bus or detritus wiring.
- Do not print/leak secret env values (MCP env blocks may hold tokens).
- In-scope work ships now; genuinely separate features are split; hard blockers
  are surfaced, never silently deferred.

## Verification command (canonical green gate, run per repo)
    go build ./... && go test ./...
Plus a behavior-level check: a spawned agent can actually reach an inherited MCP
server's tools (not just that a config was written).

🍬 Opened by [candyland](https://github.com/benitogf/candyland).