### PR TITLE
Align the origin-MCP handshake contract between detritus and candyland

### DIFF
--- a/candyland_client.go
+++ b/candyland_client.go
@@ -502,7 +502,7 @@ func ensureCandylandUp(detritusPath string) error {
 	// tools, etc.) from ~/.claude.json and hand them to candyland so it can graft
 	// the SAME tool surface into each spawned agent's --mcp-config. We write the
 	// --mcp-config-shaped JSON to a private temp file and pass only its PATH via
-	// DETRITUS_ORIGIN_MCP — never the inline JSON. The servers may carry secret
+	// CANDYLAND_INHERITED_MCP — never the inline JSON. The servers may carry secret
 	// env values (API keys); keeping them in a 0600 file rather than an env value
 	// avoids leaking them through process/env inspection. Best-effort: a
 	// missing/unreadable config or a write failure just means no extra servers to
@@ -534,7 +534,13 @@ func ensureCandylandUp(detritusPath string) error {
 // --mcp-config-shaped object ({"mcpServers": {...}}), NOT the JSON itself — the
 // servers can contain secret env values, so we never place them in an env value.
 // Empty/absent means nothing extra to inherit.
-const detritusOriginMCPEnv = "DETRITUS_ORIGIN_MCP"
+//
+// The name MUST match what candyland's conductor reads (inheritedMCPServers in
+// internal/conductor/coordinator.go). candyland reads CANDYLAND_INHERITED_MCP as
+// the path to an --mcp-config file and merges those servers into every spawned
+// agent's config, so we export under that exact name — otherwise the handshake is
+// silently dropped and no inherited servers reach the agents.
+const detritusOriginMCPEnv = "CANDYLAND_INHERITED_MCP"
 
 // originMCPExcluded are server names never propagated as inherited servers.
 // detritus rides via DETRITUS_BIN (candyland registers it passively) and
@@ -614,13 +620,29 @@ func mcpServersFromConfig(data map[string]any, cwd string) map[string]any {
 	return out
 }
 
+// originMCPConfigPath is the STABLE path of the inherited-MCP config file handed
+// to candyland. It is deliberately fixed (not a random temp name): the file must
+// outlive our process — candyland re-reads it on every agent spawn for its whole
+// lifetime — so we cannot delete it after launch. A stable path means each launch
+// overwrites the previous file rather than leaving a new random one behind, so the
+// secret-bearing config can never accumulate past a single file in TMPDIR.
+func originMCPConfigPath() string {
+	return filepath.Join(os.TempDir(), "detritus-origin-mcp.json")
+}
+
 // writeOriginMCPConfigFile serializes servers as an --mcp-config-shaped JSON
-// object ({"mcpServers": {...}}) and writes it to a private (0600) temp file,
-// returning the file path for propagation via DETRITUS_ORIGIN_MCP. It returns
-// ("", nil) when there are no servers to inherit (so the caller omits the env
-// var). The file — not an env value — carries the servers because they may hold
-// secret env values; 0600 keeps them readable only by the current user.
+// object ({"mcpServers": {...}}) and writes it to a private (0600) file at the
+// stable originMCPConfigPath, returning that path for propagation via
+// CANDYLAND_INHERITED_MCP. It returns ("", nil) when there are no servers to
+// inherit (so the caller omits the env var). The file — not an env value —
+// carries the servers because they may hold secret env values; 0600 keeps them
+// readable only by the current user. Writing to a fixed path (not os.CreateTemp)
+// bounds the on-disk secret to a single file that each launch overwrites: candyland
+// re-reads it per agent spawn, so it cannot be removed after launch, and random
+// per-launch names would otherwise accumulate indefinitely. Any stale
+// randomly-named files written by earlier detritus versions are swept first.
 func writeOriginMCPConfigFile(servers map[string]any) (string, error) {
+	sweepStaleOriginMCPConfigFiles()
 	if len(servers) == 0 {
 		return "", nil
 	}
@@ -628,14 +650,12 @@ func writeOriginMCPConfigFile(servers map[string]any) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	f, err := os.CreateTemp("", "detritus-origin-mcp-*.json")
+	name := originMCPConfigPath()
+	// Remove any pre-existing file (possibly a dangling symlink or another user's
+	// file) before creating ours with O_EXCL so we never write through it.
+	os.Remove(name)
+	f, err := os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
 	if err != nil {
-		return "", err
-	}
-	name := f.Name()
-	if err := os.Chmod(name, 0o600); err != nil {
-		f.Close()
-		os.Remove(name)
 		return "", err
 	}
 	if _, err := f.Write(out); err != nil {
@@ -648,6 +668,20 @@ func writeOriginMCPConfigFile(servers map[string]any) (string, error) {
 		return "", err
 	}
 	return name, nil
+}
+
+// sweepStaleOriginMCPConfigFiles removes secret-bearing config files left in
+// TMPDIR by earlier detritus versions, which used random per-launch temp names
+// (detritus-origin-mcp-*.json) and never cleaned them up. Best-effort: glob/remove
+// errors are ignored — a failed sweep must never block a launch.
+func sweepStaleOriginMCPConfigFiles() {
+	matches, err := filepath.Glob(filepath.Join(os.TempDir(), "detritus-origin-mcp-*.json"))
+	if err != nil {
+		return
+	}
+	for _, m := range matches {
+		os.Remove(m)
+	}
 }
 
 // candylandHealthy reports whether the sidecar answers GET /api/health with 200.

--- a/candyland_client.go
+++ b/candyland_client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -497,6 +498,20 @@ func ensureCandylandUp(detritusPath string) error {
 		selfExe = detritusPath
 	}
 	cmd.Env = append(os.Environ(), "DETRITUS_BIN="+selfExe)
+	// Enumerate the origin Claude session's OTHER MCP servers (obsidian, project
+	// tools, etc.) from ~/.claude.json and hand them to candyland so it can graft
+	// the SAME tool surface into each spawned agent's --mcp-config. We write the
+	// --mcp-config-shaped JSON to a private temp file and pass only its PATH via
+	// DETRITUS_ORIGIN_MCP — never the inline JSON. The servers may carry secret
+	// env values (API keys); keeping them in a 0600 file rather than an env value
+	// avoids leaking them through process/env inspection. Best-effort: a
+	// missing/unreadable config or a write failure just means no extra servers to
+	// inherit, never a failed launch, and no secret is ever printed. detritus
+	// rides via DETRITUS_BIN above and candyland is never a child server, so both
+	// are dropped from the inherited set.
+	if path, err := writeOriginMCPConfigFile(readOriginMCPServers(originClaudeConfigPath(), originCWD())); err == nil && path != "" {
+		cmd.Env = append(cmd.Env, detritusOriginMCPEnv+"="+path)
+	}
 	detachProcess(cmd)
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("start candyland (%s): %w", bin, err)
@@ -512,6 +527,127 @@ func ensureCandylandUp(detritusPath string) error {
 		time.Sleep(250 * time.Millisecond)
 	}
 	return fmt.Errorf("candyland did not become healthy within 20s after start")
+}
+
+// detritusOriginMCPEnv is the env var carrying the origin session's inherited
+// MCP servers to candyland. Its VALUE is the path to a temp JSON file holding an
+// --mcp-config-shaped object ({"mcpServers": {...}}), NOT the JSON itself — the
+// servers can contain secret env values, so we never place them in an env value.
+// Empty/absent means nothing extra to inherit.
+const detritusOriginMCPEnv = "DETRITUS_ORIGIN_MCP"
+
+// originMCPExcluded are server names never propagated as inherited servers.
+// detritus rides via DETRITUS_BIN (candyland registers it passively) and
+// candyland is deliberately never registered as a child MCP (see setup.go), so
+// re-inheriting either would double-register or recurse.
+var originMCPExcluded = map[string]bool{"detritus": true, "candyland": true}
+
+// originClaudeConfigPath is the origin Claude session's config file
+// (~/.claude.json), where its MCP servers are registered. Returns "" when the
+// home directory can't be resolved, which readOriginMCPServers degrades to "no
+// servers to inherit".
+func originClaudeConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".claude.json")
+}
+
+// originCWD is the current working directory used to resolve the project-scoped
+// MCP servers, or "" when it can't be determined (only the global servers apply).
+func originCWD() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	return cwd
+}
+
+// readOriginMCPServers reads claudeConfigPath and returns the origin session's
+// MCP servers for cwd (mcpServersFromConfig). It is best-effort: a
+// missing/empty/unparseable config or empty path yields an empty map (nothing to
+// inherit), never an error — inheriting the tool surface must never fail a launch.
+func readOriginMCPServers(claudeConfigPath, cwd string) map[string]any {
+	if claudeConfigPath == "" {
+		return map[string]any{}
+	}
+	raw, err := os.ReadFile(claudeConfigPath)
+	if err != nil || len(raw) == 0 {
+		return map[string]any{}
+	}
+	data := map[string]any{}
+	if err := json.Unmarshal(raw, &data); err != nil {
+		return map[string]any{}
+	}
+	return mcpServersFromConfig(data, cwd)
+}
+
+// mcpServersFromConfig extracts the inheritable MCP servers from a parsed
+// ~/.claude.json: the global "mcpServers" map merged with the project-scoped map
+// for cwd ("projects".<cwd>."mcpServers"), the project scope winning on key
+// collisions (it is the more specific one the origin session actually loaded).
+// Servers in originMCPExcluded are dropped. Pure (parsed config + cwd in → map
+// out) so the merge/exclusion is separately testable.
+func mcpServersFromConfig(data map[string]any, cwd string) map[string]any {
+	out := map[string]any{}
+	merge := func(m map[string]any) {
+		for name, spec := range m {
+			if originMCPExcluded[name] {
+				continue
+			}
+			out[name] = spec
+		}
+	}
+	if global, ok := data["mcpServers"].(map[string]any); ok {
+		merge(global)
+	}
+	if cwd != "" {
+		if projects, ok := data["projects"].(map[string]any); ok {
+			if project, ok := projects[cwd].(map[string]any); ok {
+				if scoped, ok := project["mcpServers"].(map[string]any); ok {
+					merge(scoped)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// writeOriginMCPConfigFile serializes servers as an --mcp-config-shaped JSON
+// object ({"mcpServers": {...}}) and writes it to a private (0600) temp file,
+// returning the file path for propagation via DETRITUS_ORIGIN_MCP. It returns
+// ("", nil) when there are no servers to inherit (so the caller omits the env
+// var). The file — not an env value — carries the servers because they may hold
+// secret env values; 0600 keeps them readable only by the current user.
+func writeOriginMCPConfigFile(servers map[string]any) (string, error) {
+	if len(servers) == 0 {
+		return "", nil
+	}
+	out, err := json.Marshal(map[string]any{"mcpServers": servers})
+	if err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp("", "detritus-origin-mcp-*.json")
+	if err != nil {
+		return "", err
+	}
+	name := f.Name()
+	if err := os.Chmod(name, 0o600); err != nil {
+		f.Close()
+		os.Remove(name)
+		return "", err
+	}
+	if _, err := f.Write(out); err != nil {
+		f.Close()
+		os.Remove(name)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(name)
+		return "", err
+	}
+	return name, nil
 }
 
 // candylandHealthy reports whether the sidecar answers GET /api/health with 200.

--- a/candyland_client_test.go
+++ b/candyland_client_test.go
@@ -337,6 +337,129 @@ func TestReadCampaignRunArgs(t *testing.T) {
 	}
 }
 
+// mcpServersFromConfig merges the global mcpServers with the project-scoped map
+// for cwd (project winning on collisions) and drops detritus/candyland.
+func TestMCPServersFromConfig(t *testing.T) {
+	data := map[string]any{
+		"mcpServers": map[string]any{
+			"detritus":  map[string]any{"command": "detritus"},
+			"candyland": map[string]any{"command": "candyland"},
+			"obsidian":  map[string]any{"command": "obsidian", "args": []any{"--global"}},
+			"shared":    map[string]any{"command": "global-shared"},
+		},
+		"projects": map[string]any{
+			"/work/repo": map[string]any{
+				"mcpServers": map[string]any{
+					"projtool": map[string]any{"command": "projtool"},
+					"shared":   map[string]any{"command": "project-shared"},
+				},
+			},
+			"/other": map[string]any{
+				"mcpServers": map[string]any{"nope": map[string]any{"command": "nope"}},
+			},
+		},
+	}
+
+	got := mcpServersFromConfig(data, "/work/repo")
+
+	if _, has := got["detritus"]; has {
+		t.Error("detritus must be excluded from inherited servers")
+	}
+	if _, has := got["candyland"]; has {
+		t.Error("candyland must be excluded from inherited servers")
+	}
+	if _, has := got["nope"]; has {
+		t.Error("a different project's servers must not leak in")
+	}
+	if _, has := got["obsidian"]; !has {
+		t.Error("global obsidian server should be inherited")
+	}
+	if _, has := got["projtool"]; !has {
+		t.Error("project-scoped server should be inherited")
+	}
+	shared, _ := got["shared"].(map[string]any)
+	if shared["command"] != "project-shared" {
+		t.Errorf("project scope should win on key collision: shared.command = %v, want project-shared", shared["command"])
+	}
+}
+
+// readOriginMCPServers degrades to an empty map (never errors) for a missing
+// path, an empty path, or unparseable JSON — inheriting must never fail a launch.
+func TestReadOriginMCPServers(t *testing.T) {
+	if got := readOriginMCPServers("", "/work/repo"); len(got) != 0 {
+		t.Errorf("empty path should yield no servers, got %v", got)
+	}
+
+	dir := t.TempDir()
+	if got := readOriginMCPServers(filepath.Join(dir, "nope.json"), "/work/repo"); len(got) != 0 {
+		t.Errorf("missing file should yield no servers, got %v", got)
+	}
+
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := readOriginMCPServers(bad, "/work/repo"); len(got) != 0 {
+		t.Errorf("unparseable config should yield no servers, got %v", got)
+	}
+
+	good := filepath.Join(dir, "claude.json")
+	if err := os.WriteFile(good, []byte(`{"mcpServers":{"obsidian":{"command":"obsidian"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := readOriginMCPServers(good, "/work/repo")
+	if _, has := got["obsidian"]; !has {
+		t.Errorf("obsidian server should be read from config, got %v", got)
+	}
+}
+
+// writeOriginMCPConfigFile writes the servers to a private temp file and returns
+// its PATH (not inline JSON). Its VALUE for the env var must be a readable path
+// to a 0600 file whose content is an --mcp-config-shaped object; no servers
+// yields ("", nil) so the caller omits the env var entirely.
+func TestWriteOriginMCPConfigFile(t *testing.T) {
+	if path, err := writeOriginMCPConfigFile(map[string]any{}); err != nil || path != "" {
+		t.Errorf("no servers should yield (\"\", nil), got (%q, %v)", path, err)
+	}
+	if path, err := writeOriginMCPConfigFile(nil); err != nil || path != "" {
+		t.Errorf("nil servers should yield (\"\", nil), got (%q, %v)", path, err)
+	}
+
+	path, err := writeOriginMCPConfigFile(map[string]any{"obsidian": map[string]any{"command": "obsidian", "env": map[string]any{"TOKEN": "secret"}}})
+	if err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+	defer os.Remove(path)
+
+	// The returned value is a path to a real file, not inline JSON.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("returned path is not a readable file: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("temp file should be 0600, got %v", info.Mode().Perm())
+	}
+	if json.Valid([]byte(path)) {
+		t.Errorf("env value should be a path, not inline JSON, got %q", path)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("file content is not valid JSON: %v", err)
+	}
+	servers, ok := parsed["mcpServers"].(map[string]any)
+	if !ok {
+		t.Fatalf("file missing mcpServers key: %v", parsed)
+	}
+	if _, has := servers["obsidian"]; !has {
+		t.Errorf("mcpServers should contain obsidian, got %v", servers)
+	}
+}
+
 // ensureCandylandUp returns nil immediately when the health endpoint already
 // answers 200 — no binary needed.
 func TestEnsureCandylandUpAlreadyHealthy(t *testing.T) {


### PR DESCRIPTION
Delivered by a candyland run.

## Request

Align the origin-MCP handshake contract between detritus and candyland

Why: detritus PR #109 sets env DETRITUS_ORIGIN_MCP with inline JSON (candyland_client.go: detritusOriginMCPEnv="DETRITUS_ORIGIN_MCP"), but candyland PR #22 reads env CANDYLAND_INHERITED_MCP as a file PATH (coordinator.go:186). The name and mechanism mismatch means no inherited server ever propagates end-to-end; grep in candyland finds no reference to DETRITUS_ORIGIN_MCP. The quest's behavior-level done (inherited tool reachable from a spawned agent) cannot pass until the two sides agree on one env var name and one transport (inline-JSON vs file-path).

This is one work item of the quest: # Objective: candyland agents inherit the origin session's MCP servers

## North star
A developer running candyland must get the **same MCP capabilities their VSCode
Claude session has**. Whatever MCP servers are configured/available in the origin
(VSCode) Claude session — which differ from dev to dev — must be available to the
agents candyland spawns. Nothing about the inherited set may be hardcoded.

## The problem today
Candyland spawns each agent (tech-lead / coders / quest lead / reviewers) as a
headless `claude -p ... --mcp-config <file>` process. That per-agent config
(`internal/conductor/coordinator.go` `busMCPConfig`) contains ONLY:
  - `candyland-comms` (HTTP, the ooo coordination bus)
  - `detritus` (stdio, for kb_*/code_*/skill_* — the Composition Constraint)
The developer's own MCP servers (their VSCode session's servers — user
`~/.claude.json`, project `.mcp.json`, and any VSCode-managed set) are NOT
deliberately propagated. So an agent cannot use the MCPs the dev relies on, and
candyland does not match the dev's VSCode capabilities.

## What "done" looks like
- Agents candyland spawns have access to the full set of MCP servers available in
  the origin session, in ADDITION to the candyland-comms + detritus servers they
  already get (which must keep working).
- The inherited set is discovered dynamically at launch — never a hardcoded list.
  Two devs with different MCP setups each get their own set with no code change.
- Behavior is verified by actually observing an inherited MCP tool being reachable
  from a spawned agent, not merely by asserting a config file was written.

## Likely architecture (the quest confirms/refines — do not treat as fixed)
- **detritus** is itself the MCP server the VSCode session connects to and the
  launcher that starts the candyland sidecar. It is uniquely positioned to
  enumerate the origin session's MCP configuration and hand it to candyland at
  launch (e.g. via env/handshake), rather than candyland guessing. This is the
  probable detritus-side PR.
- **candyland** merges that inherited set into each per-agent `--mcp-config` it
  writes (preserving candyland-comms + detritus), being careful about claude's
  merge-vs-strict semantics and about secrets/env propagation. This is the
  probable candyland-side PR.
- Investigate whether claude already merges the user's configured MCP servers when
  `--mcp-config` is passed WITHOUT `--strict-mcp-config`, and whether the headless
  candyland process runs with the HOME/cwd that makes those config files reachable
  — the real fix may be as much about reachability as about copying a list.

## Scope
- `github.com/benitogf/candyland`
- `github.com/benitogf/detritus`
Open one PR per repo that receives changes. Both are public benitogf repos — never
leak any idx product/customer/device names into code, commits, issues, or PRs.

## Safety boundary
- Discover the inherited MCP set dynamically; no hardcoded server lists.
- Do not weaken existing coordination-bus or detritus wiring.
- Do not print/leak secret env values (MCP env blocks may hold tokens).
- In-scope work ships now; genuinely separate features are split; hard blockers
  are surfaced, never silently deferred.

## Verification command (canonical green gate, run per repo)
    go build ./... && go test ./...
Plus a behavior-level check: a spawned agent can actually reach an inherited MCP
server's tools (not just that a config was written).

🍬 Opened by [candyland](https://github.com/benitogf/candyland).