### PR TITLE
candyland-client: pass a title-friendly prompt so runs get meaningful titles

### DIFF
--- a/candyland_client.go
+++ b/candyland_client.go
@@ -41,6 +41,36 @@ func readCandylandRunArgs(promptFile string, folders []string, cwd string) (prom
 	return string(raw), folders, nil
 }
 
+// titleFriendlyPrompt cleans the prompt's FIRST non-empty line so candyland's
+// client-side suggestTitle (first line, /-commands stripped, first 7 words) yields
+// a meaningful run title instead of a markdown artifact. Plan files usually open
+// with a heading like "# Plan: <topic>", which suggestTitle would surface as
+// "# Plan: …" — so strip the leading heading markers and a leading "Plan:" /
+// "Plan —" label, leaving the topic itself as the title line. The body is
+// untouched (the agent still receives the full plan); only the leading line is
+// normalized, and only when it is a heading — a plain first line is left as-is.
+func titleFriendlyPrompt(raw string) string {
+	lines := strings.Split(raw, "\n")
+	for i, ln := range lines {
+		if strings.TrimSpace(ln) == "" {
+			continue
+		}
+		cleaned := strings.TrimLeft(ln, "#")
+		cleaned = strings.TrimSpace(cleaned)
+		for _, prefix := range []string{"Plan:", "Plan —", "Plan -"} {
+			if len(cleaned) >= len(prefix) && strings.EqualFold(cleaned[:len(prefix)], prefix) {
+				cleaned = strings.TrimSpace(cleaned[len(prefix):])
+				break
+			}
+		}
+		if cleaned != "" && cleaned != ln {
+			lines[i] = cleaned
+		}
+		break // only the first non-empty line is the title line
+	}
+	return strings.Join(lines, "\n")
+}
+
 // runCandyland is the `detritus --candyland-run <prompt-file> [folder ...]`
 // handler: read the plan, ensure the sidecar is up, start the run, and print the
 // run id + dashboard URL. ensureCandylandUp failures are returned so the caller
@@ -50,6 +80,8 @@ func runCandyland(detritusPath, promptFile string, folders []string, cwd string)
 	if err != nil {
 		return err
 	}
+	// Normalize the leading line so suggestTitle produces a meaningful title.
+	prompt = titleFriendlyPrompt(prompt)
 	// Recognize a PR-feedback run so it updates the existing PR in place instead
 	// of opening a new one. The primary repo (folders[0]) is where a
 	// branch-state fallback looks for an open PR.

--- a/candyland_client_test.go
+++ b/candyland_client_test.go
@@ -365,3 +365,33 @@ func TestCandylandHealthyAtDown(t *testing.T) {
 		t.Error("a 500 health response must not count as healthy")
 	}
 }
+
+func TestTitleFriendlyPrompt(t *testing.T) {
+	cases := []struct {
+		name, in, wantFirst string
+	}{
+		{"markdown heading", "# Plan: campaign/quest agents\n\nbody here", "campaign/quest agents"},
+		{"heading no label", "## Fix the emoji squares\n\nbody", "Fix the emoji squares"},
+		{"plain first line untouched", "Add typed cancellation\n\nbody", "Add typed cancellation"},
+		{"leading blank lines", "\n\n# Plan: do the thing\nbody", "do the thing"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := titleFriendlyPrompt(c.in)
+			first := ""
+			for _, ln := range strings.Split(got, "\n") {
+				if strings.TrimSpace(ln) != "" {
+					first = strings.TrimSpace(ln)
+					break
+				}
+			}
+			if first != c.wantFirst {
+				t.Errorf("first line = %q, want %q", first, c.wantFirst)
+			}
+			// The body must survive untouched.
+			if !strings.Contains(got, "body") {
+				t.Errorf("body dropped: %q", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #113. Companion to the candyland dashboard/UX overhaul ([candyland PR #26](https://github.com/benitogf/candyland/pull/26)).

## What changed
Before POSTing a candyland run, detritus normalizes the leading line of the plan it passes — stripping a markdown heading marker and a leading "Plan:" label — so candyland's title derivation yields the topic itself instead of "# Plan: …". The plan body handed to the agent is untouched, and PR-feedback detection (which reads "PR #N" markers) is unaffected because only the first line's leading markers are cleaned.

## Verification
`go build ./...` green; new table-driven test covers headings, plain lines, blank-line prefixes, and body preservation.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
