### PR TITLE
Compose 'converge, don't spray' into core/build (quest + campaign thin refs)

### DIFF
--- a/docs/core/build.md
+++ b/docs/core/build.md
@@ -45,6 +45,14 @@ When all the work for the branch is green:
 
 What a branch / PR reports as **delivered** must be honest: a branch carrying only unwired (dead-in-prod) units, or a delivery step that opened no PR while in-scope work is still open, is **not** a delivery and is not reported as `done`-success — it carries the distinct terminal state `core/completion` → *Honest terminal state* defines. The one legitimate `prsOpened:0` is **branch delivery** (`deliver=="branch"`): the unit is committed onto the shared branch by design and the parent campaign opens the PR (see *Multi-repo delivery*).
 
+### One deliverable, one PR — converge, don't spray
+
+A builder or loop iterating toward a single deliverable **converges on one PR** — it never opens a pile of competing PRs for the same work. This is the delivery-side companion to `core/completion`'s exit gate (re-attempts are remediation, not new artifacts) and the build-scope analogue of `/gh`'s **one-issue-one-PR** rule. Every builder that composes this contract — a single run, an iterative loop (`/quest`, `/janitor`), or a program (`/campaign`) — inherits it:
+
+- **One PR per DISTINCT shippable item, per impacted repo** — never repeated PRs for the *same* item. "Opens many PRs over time" (an iterative loop) means one per distinct item, not many attempts at one.
+- **Once a PR is open for a deliverable, keep working it in place.** Every later attempt at that same deliverable delivers **onto the existing PR** — `deliver: feedback` on its head branch (commit, push, update in place), never a fresh PR. New PRs are only for genuinely new, non-overlapping work.
+- **Re-attempts are remediation, not new artifacts.** Opening PR #B to "reconcile" #A, then #C to "supersede #A/#B", is **thrash** — it externalizes iteration as conflicting PRs a human must untangle. The tell is a repo accumulating **reconcile / consolidate / fold #N / supersede #N** PR titles for one deliverable instead of a single PR iterated to done.
+
 Merging, deploying, and any irreversible/external action stay outside the build contract — the human's call.
 
 ## Multi-repo delivery — one feature, a PR per impacted repo

--- a/docs/flows/build/campaign.md
+++ b/docs/flows/build/campaign.md
@@ -59,6 +59,15 @@ A campaign launches at `L2`, but its **delivery mode** still tracks what the inp
 
 The `--campaign-run` launcher **derives** the delivery mode from the campaign input — reusing the same derivation the quest launcher uses (`deriveQuestDelivery`): a feedback/review **verb** plus a parsed **PR reference** (`#N`) selects `feedback`/`review` carrying that target PR, and anything else falls back to `deliver: pr` (new work). It then sends `deliver`/`targetPr` on the `POST /api/campaigns` body, and candyland propagates them to the affected child quests/runs. Note this is **not** how autonomy is set: campaign autonomy is **fixed at `L2`** (never derived, never `L1`), whereas the delivery mode is derived per the input's verb + PR reference. The launcher **never** opens a duplicate PR for a feedback/review input, and never silently defaults a feedback/review input to `pr`.
 
+### The program converges — it does not spray competing PRs
+
+The same **converge, don't spray** rule the quest loop obeys (`flows/build/quest` → *One deliverable, one PR*) holds at the **program level**, and even harder — a campaign coordinates *many* children, so the potential to litter a repo with overlapping PRs is larger. The campaign's shape enforces convergence, and every child must respect it:
+
+- **One PR per impacted repo, from the shared campaign branch.** Child quests/runs decomposed by a campaign **commit onto the campaign branch** (`deliver: branch`) and open **no PR of their own** — the campaign opens the single per-repo PR at delivery. A child that opens its own competing PR for campaign-owned work has broken the model.
+- **Re-attempts are remediation on the same deliverable, never a new PR.** When the intent review finds a commitment unmet, the campaign spawns a remediation run targeting **exactly that commitment** onto the same branch and re-reviews (the `core/completion` exit-gate rule above) — it does **not** open a fresh "reconcile"/"consolidate"/"supersede" PR. A pile of such PRs is the same thrash the quest rule names, one level up: the tell that convergence broke is a repo accumulating competing PRs for one program instead of a single PR iterated to done.
+
+> **Being built:** the settled candyland plan makes this structural at the campaign tier — a campaign decomposes into **child quests** that commit to the campaign branch (no per-quest PR), and a stakeholder + tech-lead pair converge the program to done (plan **Bucket B**) rather than letting children each open PRs. Until that lands, hold to the rule above.
+
 ## Control (stop only)
 
 Like `/candyland` and `/quest`, a campaign is lean: **observe + audit + stop**, no per-agent control, no resume. Halt a wrong or runaway campaign from the dashboard's Stop — candyland owns the spawned process tree, so it genuinely kills the conductor + child quests/runs. Watch live state in the dashboard rather than polling.

--- a/docs/flows/build/campaign.md
+++ b/docs/flows/build/campaign.md
@@ -59,14 +59,11 @@ A campaign launches at `L2`, but its **delivery mode** still tracks what the inp
 
 The `--campaign-run` launcher **derives** the delivery mode from the campaign input — reusing the same derivation the quest launcher uses (`deriveQuestDelivery`): a feedback/review **verb** plus a parsed **PR reference** (`#N`) selects `feedback`/`review` carrying that target PR, and anything else falls back to `deliver: pr` (new work). It then sends `deliver`/`targetPr` on the `POST /api/campaigns` body, and candyland propagates them to the affected child quests/runs. Note this is **not** how autonomy is set: campaign autonomy is **fixed at `L2`** (never derived, never `L1`), whereas the delivery mode is derived per the input's verb + PR reference. The launcher **never** opens a duplicate PR for a feedback/review input, and never silently defaults a feedback/review input to `pr`.
 
-### The program converges — it does not spray competing PRs
+### The program converges — one PR per repo
 
-The same **converge, don't spray** rule the quest loop obeys (`flows/build/quest` → *One deliverable, one PR*) holds at the **program level**, and even harder — a campaign coordinates *many* children, so the potential to litter a repo with overlapping PRs is larger. The campaign's shape enforces convergence, and every child must respect it:
+A campaign obeys `core/build` → *One deliverable, one PR — converge, don't spray*, and the program's shape enforces it: child quests/runs **commit onto the shared campaign branch** (`deliver: branch`) and open **no PR of their own**, so the campaign delivers **one PR per impacted repo** at the end — never a scatter of competing child PRs. Re-attempts are the remediation the exit gate above already defines (a run targeting exactly the unmet commitment onto the same branch), never a fresh "reconcile/consolidate/supersede" PR.
 
-- **One PR per impacted repo, from the shared campaign branch.** Child quests/runs decomposed by a campaign **commit onto the campaign branch** (`deliver: branch`) and open **no PR of their own** — the campaign opens the single per-repo PR at delivery. A child that opens its own competing PR for campaign-owned work has broken the model.
-- **Re-attempts are remediation on the same deliverable, never a new PR.** When the intent review finds a commitment unmet, the campaign spawns a remediation run targeting **exactly that commitment** onto the same branch and re-reviews (the `core/completion` exit-gate rule above) — it does **not** open a fresh "reconcile"/"consolidate"/"supersede" PR. A pile of such PRs is the same thrash the quest rule names, one level up: the tell that convergence broke is a repo accumulating competing PRs for one program instead of a single PR iterated to done.
-
-> **Being built:** the settled candyland plan makes this structural at the campaign tier — a campaign decomposes into **child quests** that commit to the campaign branch (no per-quest PR), and a stakeholder + tech-lead pair converge the program to done (plan **Bucket B**) rather than letting children each open PRs. Until that lands, hold to the rule above.
+The settled candyland plan makes this structural (plan **Bucket B**: campaign→child-quests on the campaign branch, a stakeholder + tech-lead pair converging the program); until it lands, the `core/build` rule holds.
 
 ## Control (stop only)
 

--- a/docs/flows/build/quest.md
+++ b/docs/flows/build/quest.md
@@ -62,13 +62,11 @@ Pairing with the autonomy-from-intent rule above, the launcher also **detects th
 
 The launcher **never** opens a duplicate PR for a feedback/review intent, and **never** silently defaults a feedback/review objective to `pr`. The intent→delivery-mode detection is the same shape as the intent→autonomy detection above: derived from the verb, or prompted once when ambiguous.
 
-### One deliverable, one PR — a quest converges, it does not spray
+### One deliverable, one PR
 
-"May open **many PRs over time**" means **one PR per DISTINCT shippable item** — never repeated, competing PRs for the **same** deliverable. Once a tick has opened a PR for an objective (or a slice of it), every later tick that keeps working **that same deliverable** delivers **onto the existing PR** (`deliver: feedback` on its head branch — commit, push, update in place), exactly as a feedback intent does. A quest opens a *new* PR only for genuinely new, non-overlapping work.
+A quest **converges on one PR per deliverable and never sprays competing PRs** — the shared rule in `core/build` → *One deliverable, one PR — converge, don't spray*. For a quest specifically: "may open **many PRs over time**" is one per **distinct** shippable item across ticks — a later tick working a deliverable an earlier tick already opened a PR for delivers **onto that PR** (`deliver: feedback`), never a new one.
 
-A quest that opens PR #A, then opens PR #B to "reconcile/fold/consolidate" #A, then PR #C to "supersede #A/#B" has **thrashed**: it externalized its own iteration as a pile of conflicting PRs a human must now untangle. This is the quest-level violation of `/gh`'s **one-issue-one-PR** rule (and of `core/completion`'s exit gate — re-attacking a deliverable is remediation *of that PR*, not a new one). Detection cues in a quest's own PR titles — "reconcile", "consolidate", "fold PR #N", "land the canonical", "supersede #N" — are a **red flag that the convergence rule was breached**; a healthy quest amends one PR until it's right.
-
-> **Being built:** the settled candyland plan enforces this structurally — a **shared quest+run gate** classifies each objective as build-on-existing-PR vs generate-new (plan **C4**), and the **quest-lead becomes a converging owner** (plan **Bucket B**) that iterates one deliverable to done rather than spawning fresh runs that each open a PR. Until that lands, the convergence rule above is the doctrine to hold to.
+The settled candyland plan makes this structural rather than disciplinary — a **shared quest+run gate** (plan **C4**) and a **converging quest-lead owner** (plan **Bucket B**); until that lands, the `core/build` rule is the doctrine to hold to.
 
 ## Launch output
 


### PR DESCRIPTION
Closes #119. Supersedes the inline duplication — makes the convergence rule composable per detritus's no-duplicated-docs principle.

## What changed
- **core/build** gains the canonical rule *One deliverable, one PR — converge, don't spray* (one PR per distinct item per repo; re-attempts deliver onto the existing PR via feedback; reconcile/consolidate/supersede PR titles are the thrash tell). Every builder that composes core/build — a run, /quest, /janitor, /campaign — inherits it.
- **flows/build/quest** and **flows/build/campaign** are reduced to short, flow-specific compositions that reference the core rule — no restatement, and neither references the other flow.
- De-dups the inline block #116 added to quest.md.

Docs-only.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)