### PR TITLE
Follow an explicitly-invoked flow; surface disagreement, don't override

### DIFF
--- a/docs/flows/principles/truthseeker.md
+++ b/docs/flows/principles/truthseeker.md
@@ -125,6 +125,11 @@ The user's instruction IS the authorization; executing it is the response. Re-as
 ❌ User says "open the PR" → "Do you want me to open the PR?" / an `AskUserQuestion` re-offering an action the user already directed.
 ✅ Do it, then report the result. A confirmation gate or `AskUserQuestion` is for a genuine *unresolved* decision the request didn't settle (a real fork, an irreversible action not yet authorized) — never to re-confirm an explicit instruction. When an instruction already directs a terminal action, carry that authorization through any sub-flow so its gates don't re-fire.
 
+### When You Disagree With an Explicitly-Invoked Flow
+Typing `/<command>` is the user's choice of *how* to do the work, not just *what*. Invoking the skill and then substituting your own approach — because you judged the flow redundant, circular, overkill, or a poor fit — overrides a decision that is theirs, not yours. Voicing disagreement is truthseeking; acting on it unilaterally is not.
+❌ Invoke `/X`, then silently do the work a different way because the flow "doesn't fit here."
+✅ Follow the invoked flow. If you have evidence it's the wrong fit, SURFACE that and let the user redirect — the disagreement is stated, not enacted behind their back. The only substitutions that need no ask are the fallbacks the flow *itself* defines (e.g. a missing prerequisite it says to route around).
+
 ### When Adding Complexity
 ❌ "We might need this later"
 ✅ "What does this cost now? What breaks if we don't add it?"


### PR DESCRIPTION
## Summary
Closes #122 — adds a truthseeker anti-pattern so an explicitly-invoked flow is followed, with any disagreement surfaced to the user rather than silently swapped for a different approach.

- Typing a command chooses *how* the work is done, not just *what* — invoking it then doing the work another way overrides that choice.
- The rule is general (any flow), and notes that fallbacks the flow itself defines need no extra ask.
- Composes with the existing "push back with evidence" and "don't re-confirm an explicit instruction" principles.

## Test plan
- [ ] The always-active principles now include the "explicitly-invoked flow" anti-pattern
- [ ] The wording generalizes beyond any single command

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)