### PR TITLE
Never-stop escalation ladder, capability-blocker postmortems, shogun-form briefs, /learn

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ and intentionally absent — they are not commands.
 | `/detritus-release` | Cut a release of detritus and/or candyland (bump → annotated tag → CI build), then update the local installation. |
 | `/detritus-update` | Update detritus to the latest released version by running `detritus --update`. |
 | `/grow` | Learn from conversation corrections - distill manual fixes into KB updates |
+| `/learn` | Learn from candyland telemetry - mine failure signatures across runs/quests/campaigns into audited KB updates |
 | `/optimize` | Re-index and optimize KB docs for agent retrieval efficiency |
 | `/setup-extra-rules` | Generate personalized Claude Code rule files and hook scripts based on the user's actual environment. |
 | `/setup-superpowers` | Apply baseline Claude Code settings (deny list, status line, effort/thinking, autoMode environment). |

--- a/candyland_client_quest_test.go
+++ b/candyland_client_quest_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestQuestLaunchSummary verifies the rendered launch output carries the pieces
+// an operator needs: the deliver mode + its honest effect line, the API URL on
+// :8888, the UI URL on :8080, and the remote/WSL forward-BOTH-ports hint.
+func TestQuestLaunchSummary(t *testing.T) {
+	out := questLaunchSummary("quest", "q-123", "pr", 0, false)
+
+	wants := []string{
+		"candyland quest started: q-123",
+		"Deliver: pr (opens a PR, never merges)",
+		":8888",
+		":8080",
+		"forward BOTH ports",
+	}
+	for _, w := range wants {
+		if !strings.Contains(out, w) {
+			t.Errorf("summary missing %q\n---\n%s", w, out)
+		}
+	}
+}
+
+// TestQuestLaunchSummaryFeedbackEffect verifies the deliver-mode effect line
+// reflects the feedback mode (updates the referenced PR in place, no new PR).
+func TestQuestLaunchSummaryFeedbackEffect(t *testing.T) {
+	out := questLaunchSummary("adventure", "a-9", "feedback", 42, false)
+
+	if !strings.Contains(out, "candyland adventure started: a-9") {
+		t.Errorf("summary missing adventure kind/id line\n---\n%s", out)
+	}
+	if !strings.Contains(out, "Deliver: feedback (updates existing PR #42 in place — no new PR, never merges)") {
+		t.Errorf("summary missing feedback effect line\n---\n%s", out)
+	}
+}

--- a/docs/core/coder.md
+++ b/docs/core/coder.md
@@ -25,6 +25,20 @@ Shared contract for every implementation-loop coder role. A coder is **not** a p
 > ## ⛔ Do not invoke directly
 > This is an internal building block with no slash command. It is loaded via `kb_get` by a role agent that a tech-lead (`roles/tech-lead`) has spawned — either as an in-process sub-agent under `/forge` or as a candyland-launched process. A coder never owns the loop, never spawns other agents, and never opens a PR.
 
+## Forbidden actions (CO-F#)
+
+Checkable prohibitions for a coder. A single row fired = the coder is off-contract.
+
+| ID | Forbidden action | Instead | Why (one line) |
+|----|------------------|---------|----------------|
+| CO-F1 | Reaching across the fork-safe boundary (editing a file outside the assigned set) | Report it — escalate to the tech-lead to re-partition or widen the boundary | The cross-dependency the partition exists to prevent; a reach-across races other coders' worktrees. |
+| CO-F2 | Asking the user anything (a decision, a clarification, "which way?") | Emit the fenced `BLOCKED {json:{question, correlationId}}` line to the **tech-lead** | Post-plan no decision reaches the user; the tech-lead is the coder's one tier up (`core/coordination`, `core/completion`). |
+| CO-F3 | Integrating branches, resolving cross-task conflicts, or opening a PR | Leave it — the tech-lead integrates sequentially and delivers | A coder integrating erases the test-defined contract and hides regressions. |
+| CO-F4 | Using `blocked` for a *decision* (ambiguity, difficulty, "unclear how"), or to skip root-cause analysis | Escalate the decision to the tech-lead; investigate the root cause before any `blocked` | `blocked` is **capability-failure only** and a last breath, not a shortcut past work or investigation (`core/completion`). |
+
+✅ Interface `X` is undefined in my boundary → emit `BLOCKED {"question":"interface X is undefined in my boundary — provide it or widen scope?","correlationId":"task-export-3"}` to the tech-lead.
+❌ Interface `X` is undefined → open the file outside my boundary and define it myself (CO-F1), or ask the user which signature to use (CO-F2).
+
 ## Inputs a coder receives
 
 The tech-lead hands each coder exactly four things — never the whole plan:
@@ -40,7 +54,41 @@ The tech-lead hands each coder exactly four things — never the whole plan:
 - **Stay inside the partition.** Touch only the files in the assigned boundary. A change that needs a file outside the boundary is a **blocker to report**, not a license to reach across — reaching across is exactly the cross-dependency the fork-safe partition exists to prevent.
 - **Smallest delta to green.** Implement the task, not adjacent improvements. Out-of-scope needs are reported, never folded in (see *Out-of-scope work* below).
 - **No integration.** A coder never merges branches, resolves cross-task conflicts, or opens a PR. Integration is the tech-lead's sequential step.
-- **Emit status, don't narrate.** A coder's output is a structured status the driver consumes (the `/forge` sub-agent return value, or a candyland event): `working` → `green` (task done, test + verification green, files changed) or `blocked` (with the precise evidence — failing assertion, missing interface, out-of-boundary dependency). In-process, a block ends the turn with `core/coordination`'s fenced `BLOCKED {json: {question, correlationId}}` line so the orchestrator can answer and re-spawn. Status is the only product; raw logs stay out of the user's thread.
+- **Emit status, don't narrate.** A coder's output is a structured status the driver consumes (the `/forge` sub-agent return value, or a candyland event). In-process, a block ends the turn with `core/coordination`'s fenced `BLOCKED {json: {question, correlationId}}` line so the orchestrator can answer and re-spawn. Status is the only product; raw logs stay out of the user's thread.
+
+### Coder status — closed enum
+
+`(do NOT invent others)`:
+
+- `working` — task in progress (transient).
+- `green` — task done: the defining test is green AND the canonical verification passes AND `files` lists what changed. Any missing part = not `green`.
+- `blocked` — a **capability failure** only (missing creds/permissions/infra/toolchain-outside-repo), postmortem-backed per `core/completion`. A *decision* is NEVER `blocked` (see CO-F4); a decision escalates via the fenced `BLOCKED {json}` line to the tech-lead and the coder waits to be re-spawned with the answer.
+
+### Escalation — a blocked coder escalates to the tech-lead, never the user (E1)
+
+The coder is the bottom tier of the escalation ladder (`core/coordination`, `core/completion`). When a **decision** is beyond the coder (ambiguity, trade-off, a boundary that must widen), it escalates **exactly one tier up — to the tech-lead** — with the fenced line:
+
+```
+BLOCKED {"question":"interface X is undefined in my boundary — provide it or widen scope?","correlationId":"task-export-3"}
+```
+
+The tech-lead decides, records it, and re-spawns the coder with the answer rendered into its brief. A genuine **capability blocker** (§CO-F4) stops with a postmortem instead (`core/completion` schema). Neither path reaches the user.
+
+✅ Decision beyond the coder → fenced `BLOCKED {json}` to the tech-lead; coder ends the turn and waits for re-spawn.
+❌ Decision beyond the coder → prompt the user, or terminal-`blocked` the task to dodge the ambiguity (CO-F4).
+
+### Report schema (the `green` hand-off)
+
+A `green` return carries these mandatory fields — **missing field = incomplete → the tech-lead bounces it back**:
+
+| Field | Meaning |
+|-------|---------|
+| `status` | `green` (closed enum above) |
+| `task` | the task id/slug this coder owned |
+| `test` | the defining test, now green (the exact command/name) |
+| `verification` | the canonical verification command that passed |
+| `files` | every file changed, all inside the assigned boundary |
+| `notes` | out-of-scope needs / risky adjacent code observed (tech-lead triages per `core/completion`) — empty if none, never omitted |
 
 ## Out-of-scope work
 

--- a/docs/core/coder.md
+++ b/docs/core/coder.md
@@ -92,4 +92,4 @@ A `green` return carries these mandatory fields — **missing field = incomplete
 
 ## Out-of-scope work
 
-A coder reports out-of-scope needs or risky adjacent code to the tech-lead as part of its `blocked`/status output — it never acts on them or folds them in. Disposition is the tech-lead's call per `core/completion`'s three dispositions (`roles/tech-lead` → *Dispositions*): in-scope work is done now, a genuinely separate feature becomes a feature-split, a hard blocker is surfaced. A coder never converts an in-scope need into a deferral.
+A coder reports out-of-scope needs or risky adjacent code to the tech-lead as part of its `blocked`/status output — it never acts on them or folds them in. Disposition is the tech-lead's call per `core/completion`'s three dispositions (`roles/tech-lead` → *Dispositions*): in-scope work is done now, a genuinely separate feature becomes a feature-split, a capability blocker is surfaced. A coder never converts an in-scope need into a deferral.

--- a/docs/core/completion.md
+++ b/docs/core/completion.md
@@ -213,7 +213,7 @@ delivery the mode promised did not land). Rules:
 - **Feed the error back**, don't strand it. The git/gh error text is usually **machine-fixable** by an
   agent that reads it (e.g. a push blocked by secret scanning → remove the offending file/history; a
   non-fast-forward → rebase). In a loop/campaign this is a remediation round on the delivery error
-  itself, bounded like any other; only a failure that survives the budget is a real hard blocker.
+  itself, bounded like any other; only a failure that survives the budget is a real capability blocker.
 - **A multi-unit deliverable (e.g. one PR per repo) is not `done` until *every* impacted unit delivered.**
   One unit's delivery failure is isolated from the others but keeps the whole out of clean `done`.
 

--- a/docs/core/completion.md
+++ b/docs/core/completion.md
@@ -76,7 +76,7 @@ Each acceptance criterion is written as a verifiable contract: the **desired end
 ## The three dispositions
 
 For ANY work a builder or loop encounters, exactly one disposition applies. This is a **closed enum —
-`1 in-scope-now | 2 feature-split | 3 hard-blocker` (do NOT invent others)**. "Hazard" is **not** a
+`1 in-scope-now | 2 feature-split | 3 capability-blocker` (do NOT invent others)**. "Hazard" is **not** a
 fourth option — it is retired as a catch-all and resolves only to disposition 2 or 3.
 
 1. **In-scope & handle-able now → DO IT NOW.** The default; it covers the vast majority. No phases, no
@@ -90,7 +90,7 @@ fourth option — it is retired as a catch-all and resolves only to disposition 
      *Blockers & feature-splits* section.
    - Autonomous (`/vibe`): the architect decides, records, and splits a truly separate feature into its
      own plan.
-3. **Hard blocker = capability failure only → SURFACE as a blocker.** A failure **no decision can
+3. **Capability blocker = capability failure only → SURFACE as a blocker.** A failure **no decision can
    resolve**: missing credentials, absent permissions, unreachable infrastructure, a toolchain broken
    *outside* the repo. This is a **last breath, not a shortcut** — `blocked` may NOT be used to avoid
    work, skip investigation, or dodge root-cause analysis. It carries a **postmortem** (see *Closed
@@ -162,7 +162,7 @@ a deferral.
 review / verdict step reports an unmet acceptance criterion or commitment, the orchestrator must feed
 that gap back as new work — spawn a unit targeting **exactly the unmet item** (carrying the reviewer's
 evidence) and re-verify — bounded by a remediation budget (the K-attempt circuit breaker in M6). Only a
-gap that survives the budget is a disposition-3 hard blocker. Parking in terminal `blocked` on the
+gap that survives the budget is a disposition-3 capability blocker. Parking in terminal `blocked` on the
 **first** failing review while the gap is still finishable is the silent-deferral failure at the
 **orchestrator / supervisor level**, forbidden exactly as it is at the single-unit level. This binds a
 program-level supervisor reviewing per-commitment verdicts (e.g. a campaign's intent review) as much as

--- a/docs/core/completion.md
+++ b/docs/core/completion.md
@@ -75,7 +75,8 @@ Each acceptance criterion is written as a verifiable contract: the **desired end
 
 ## The three dispositions
 
-For ANY work a builder or loop encounters, exactly one disposition applies. "Hazard" is **not** a
+For ANY work a builder or loop encounters, exactly one disposition applies. This is a **closed enum —
+`1 in-scope-now | 2 feature-split | 3 hard-blocker` (do NOT invent others)**. "Hazard" is **not** a
 fourth option — it is retired as a catch-all and resolves only to disposition 2 or 3.
 
 1. **In-scope & handle-able now → DO IT NOW.** The default; it covers the vast majority. No phases, no
@@ -89,13 +90,46 @@ fourth option — it is retired as a catch-all and resolves only to disposition 
      *Blockers & feature-splits* section.
    - Autonomous (`/vibe`): the architect decides, records, and splits a truly separate feature into its
      own plan.
-3. **Hard blocker beyond the loop's authority → SURFACE as a blocker.** Irreversible/external action,
-   a genuine spec contradiction, a missing credential. The narrow exception, not the default escape
-   hatch.
+3. **Hard blocker = capability failure only → SURFACE as a blocker.** A failure **no decision can
+   resolve**: missing credentials, absent permissions, unreachable infrastructure, a toolchain broken
+   *outside* the repo. This is a **last breath, not a shortcut** — `blocked` may NOT be used to avoid
+   work, skip investigation, or dodge root-cause analysis. It carries a **postmortem** (see *Closed
+   blocker definition & postmortem schema*). The narrow exception, not the default escape hatch.
+
+**A decision is NEVER disposition 3.** A *decision* — ambiguity, a trade-off, scope interpretation, an
+unclear root cause, unexpected difficulty, "this is taking long" — is a choice the agent can resolve by
+*choosing*. It never stops the flow and never reaches the user post-plan; it **falls down the escalation
+ladder** (`core/coordination` → *Re-planning loop*), is decided at the lowest tier with authority, and
+is **recorded** (`/smith`: the ledger's *Decisions made autonomously* section; `/forge`: the tech-lead
+decides and re-spawns; candyland: exactly one tier up). Only a capability blocker is disposition 3.
+
+## Closed blocker definition & postmortem schema
+
+A **blocker (capability failure)** is a failure **no decision can resolve** — missing credentials,
+absent permissions, unreachable infrastructure, a toolchain broken *outside* the repo. It is the ONLY
+thing that legitimately reaches terminal `blocked`. It is a **last breath, not a shortcut**: `blocked`
+may NOT be used to avoid work, skip investigation, or dodge root-cause analysis. Ambiguity, trade-offs,
+difficulty, unclear root cause, and budget anxiety are **decisions**, never blockers — they fall down
+the escalation ladder (`core/coordination`).
+
+`blocked` is **invalid without ALL six postmortem fields** (missing field = incomplete → rejected/bounced):
+
+| Field | Content |
+|---|---|
+| `attempts` | each attempt made and its result. |
+| `failing_capability` | the exact capability that failed (one line). |
+| `evidence` | verbatim commands + error output proving the failure. |
+| `root_cause_so_far` | root-cause analysis as far as it got. |
+| `human_unblock_action` | precisely what a human must provide to unblock. |
+| `partial_work_state` | branch, commits, ledger refs for work already done. |
 
 ## Explicitly forbidden
 
 - Splitting agreed scope into "phase 2" / "later" to exit sooner.
+- Using `blocked` for a **decision** (ambiguity, trade-off, difficulty, unclear root cause) instead of
+  falling down the escalation ladder — a decision is never a blocker.
+- Using `blocked` as a **shortcut** to skip root-cause analysis or investigation — it is a
+  capability-failure-only last breath, and only with a complete postmortem.
 - Leaving `TODO`/`FIXME`/"future work" for a disposition-1 item.
 - Filing a follow-up issue for in-scope work instead of doing it.
 - Declaring done with an unchecked criterion or a red gate.
@@ -134,9 +168,11 @@ gap that survives the budget is a disposition-3 hard blocker. Parking in termina
 program-level supervisor reviewing per-commitment verdicts (e.g. a campaign's intent review) as much as
 a per-task coder loop — an orchestrator never parks with finishable in-scope work undone.
 
-The only legitimate hand-backs are three: **milestone / PR-open**, a **hard blocker** (disposition 3),
-or an **explicit user halt**. Anywhere else, the loop owes a next step (see `core/loop` →
-self-continuation). For a **multi-repo feature** the milestone is *every* impacted repo's PR being open
+The only legitimate hand-backs are three: **milestone / PR-open**, a **capability blocker** (disposition
+3, postmortem-backed), or an **explicit user halt**. A **decision is not a legitimate hand-back** — it
+falls down the escalation ladder (`core/coordination`), is decided at the lowest tier with authority,
+and is recorded, never surfaced to the user post-plan. Anywhere else, the loop owes a next step (see
+`core/loop` → self-continuation). For a **multi-repo feature** the milestone is *every* impacted repo's PR being open
 (`core/build` → *Multi-repo delivery*) — opening the first repo's PR is not a stopping point while
 another impacted repo still owes a PR.
 
@@ -145,8 +181,12 @@ reusable, cross-project lesson (`core/memory` → *When to distil*); an unverifi
 
 ## Honest terminal state
 
-Terminal `done` / "success" MUST reflect **actual in-scope delivery**. A run / loop / quest / PR that
-delivered **nothing** in-scope is a **distinct outcome, never `done`-as-success** — for example:
+Terminal states are a **closed enum — `done | surfaced-only | blocked | delivery-failed | stopped`
+(do NOT invent others)**. Terminal `done` / "success" MUST reflect **actual in-scope delivery**. A run
+/ loop / quest / PR that delivered **nothing** in-scope is a **distinct outcome, never `done`-as-success**
+— for example (the 2026-07-03 review found candyland dropped the `"skipped"` disposition writer, so an
+all-skip quest that executed zero items terminated plain `done` with an empty summary — the exact
+looks-done-but-isn't class this rule kills):
 
 - dead-in-prod code (passes condition 2, fails condition 2a — no production caller);
 - a report-only / zero-execution tick (work surfaced and triaged, none executed);
@@ -156,8 +196,9 @@ Reporting surfaces — CLI, dashboard, status field — must **name it as such**
 downstream flow reads a no-op as a delivery: e.g. `surfaced-only`, or
 `done (report-only: N surfaced, 0 executed, 0 PRs)`.
 
-The discriminator across every carve-out below is the **delivery mode** (`run.deliver`, one of
-`pr|branch|feedback|review` — `core/build` → *Delivery modes*), **not** the PR count. The zero-delivery
+The discriminator across every carve-out below is the **delivery mode** (`run.deliver`, a **closed enum
+— `pr | branch | feedback | review` (do NOT invent others)** — `core/build` → *Delivery modes*),
+**not** the PR count. The zero-delivery
 no-op detector flags only runs that delivered **nothing in-scope**; it must **never** flag a
 `branch`, `feedback`, or `review` run as a no-op failure.
 
@@ -243,8 +284,10 @@ Verify** (exit gates), and **Persist** (the durable ledger).
   - **Multi-process (candyland):** the **tech-lead / conductor** re-spawns a coder that stopped before
     its task's acceptance criteria + tests are green, and marks `blocked` only on a real blocker
     (`core/coordination`).
-  - Both pair with a **circuit breaker**: after **K=3** failed attempts on one unit, escalate to a
-    blocker (push the branch + record it) rather than thrash the subscription quota.
+  - Both pair with a **circuit breaker**: after **K=3** failed attempts on one unit, escalate **one tier
+    up** the ladder (`core/coordination` → *Re-planning loop*) — a *decision* is decided and recorded
+    there, never surfaced; only a **capability failure** surviving the cap becomes a postmortem-backed
+    `blocked` (push the branch + record it) — rather than thrash the subscription quota.
   - A Claude Code Stop hook (`setup-extra-rules`) is **optional local hardening** a developer may opt
     into — **not** a build deliverable and **not** the portable contract. Per-machine hooks are exactly
     the bespoke setup the portability goal avoids.

--- a/docs/core/coordination.md
+++ b/docs/core/coordination.md
@@ -39,15 +39,24 @@ ledger, the verification gate, and the K=3 escalation cap — as its coordinatio
   → *Partition emission format*. At campaign altitude the tech manager mirrors the same convention with
   a `QUESTS [...]` line — see `roles/tech-lead` → *QUESTS line format*.)
 - **Message types** (FIPA-reduced, two-tier correlation): `{from, to, type, conversationId,
-  correlationId?, ts, seq, body}`, `type ∈ {question, response, feedback, directive, task_mutation}`. A
-  `question` carries a `correlationId`; the `response` echoes it; `feedback`/`directive` are one-way.
-  `seq` is assigned by the transport, not the sender.
+  correlationId?, ts, seq, body}`, `type` is a **closed enum — `question | response | feedback |
+  directive | task_mutation` (do NOT invent others)**. A `question` carries a `correlationId`; the
+  `response` echoes it; `feedback`/`directive` are one-way. `seq` is assigned by the transport, not the
+  sender. A **decision escalation is a `question` addressed to the next tier up** (`to` = the escalation
+  recipient per the ladder); the deciding tier replies with a `response` echoing the `correlationId` —
+  the escalation is decided and recorded, never a pause for the user.
 - **Re-planning loop.** A worker raises `question` / `feedback` / `task_mutation` → the orchestrator
   **regenerates the remaining plan** (it never diffs), commits the node add/split/reprioritize, and
   sends `directive`s. The **escalation cap is the single binding convergence guard**: retry → local
-  patch → full replan, then **escalate to a blocker after K=3** attempts on a unit. This *is*
-  `core/completion`'s circuit breaker — there is no separate timer or loop-detector; an unanswered
-  `question` left `blocked` after K cycles is swept to a blocker.
+  patch → full replan, then **escalate one tier up after K=3** attempts on a unit. This *is*
+  `core/completion`'s circuit breaker — there is no separate timer or loop-detector.
+- **Escalation has a recipient — a decision escalates, it does not stop.** A `question` is a **decision**
+  (`core/completion` → *The three dispositions*), and a decision NEVER reaches the user post-plan. Its
+  recipient is **the orchestrator's own next tier up the escalation ladder**; it is **decided there and
+  recorded**, never surfaced. Only a **capability blocker** — a failure surviving the K=3 cap AND
+  unresolvable by any tier — becomes terminal `blocked`, and only with a schema-valid **postmortem**
+  (`core/completion` → *Closed blocker definition & postmortem schema*). An unanswered `question` is
+  never "swept to a blocker": it is decided one tier up. Only a capability failure is a blocker.
 - **Verification gate.** "Done" = acceptance criteria met + build/tests green, read from the **durable
   ledger** (`core/completion`), never from chat memory. The same gate governs which work distils into
   `core/memory`.
@@ -77,8 +86,10 @@ orchestration — no new Go, no daemon, no ooo bus, no comms tools.**
   BLOCKED {"question":"interface X is undefined in my boundary — provide it or widen scope?","correlationId":"task-export-3"}
   ```
 
-  The orchestrator answers, mutates the ledger if needed, and **re-spawns** the worker with the answer +
-  its updated slice. (The base Agent tool has no mid-task resume, so respawn is the mechanism — the
+  In `/forge` the orchestrator is the **tech-lead (this session)**: it **decides** the escalated
+  decision (its own fallback is the smith rule — decide the best option given context and record it in
+  the PROGRESS ledger's *Decisions made autonomously* section), mutates the ledger if needed, and
+  **re-spawns** the worker with the answer + its updated slice. (The base Agent tool has no mid-task resume, so respawn is the mechanism — the
   in-process realization of an interrupt→resume.) **Re-spawn context must be rendered, not merely
   attached.** The answer / findings / feedback the orchestrator carries forward MUST appear in the brief
   text the re-spawned worker actually reads. A field populated on the slice but never rendered into the
@@ -87,8 +98,9 @@ orchestration — no new Go, no daemon, no ooo bus, no comms tools.**
   what closes the loop, so it is **tested at the boundary**: a test asserts the carried context surfaces
   in the worker-visible brief, not just that the field is set.
 - **Enforcement** is the loop itself: it re-derives the open items and continues until the gate is green
-  (`core/completion`'s exit gate). No Stop hook required. The **K=3** escalation cap escalates a stuck
-  unit to a blocker rather than thrashing quota.
+  (`core/completion`'s exit gate). No Stop hook required. The **K=3** cap escalates a stuck unit's
+  *decision* to the tech-lead, who decides and records it; only a capability failure surviving the cap
+  becomes a postmortem-backed blocker — never thrash quota.
 - **Artifact hand-off is the filesystem / git**, not messages.
 
 ## Realization B — candyland, multi-process (the bus on the conductor)
@@ -100,7 +112,14 @@ seq+auth and an `AfterWriteFilter` to react), beside the existing stdout loop. T
 discipline holds over the bus: carried context (answer / findings / feedback) MUST be rendered into the
 brief the coder process reads — a populated-but-unrendered field is invisible context the coder
 re-derives — and a regression test asserts it surfaces in the worker-visible brief at the transport
-boundary, not merely that the field is set. **Realization B is built
+boundary, not merely that the field is set.
+
+In candyland a decision escalates **exactly one tier up** the ladder — coder → tech-lead → quest-lead →
+campaign **tech-manager** → **intent-manager** — and is decided at the lowest tier with authority. The
+top tier for each substrate (standalone-run = tech-lead; standalone-quest = quest-lead; campaign =
+intent-manager) applies the smith rule (decide + record). Escalation **never pauses for a human**; the
+dashboard shows decisions **read-only** for audit. Only a capability blocker terminates a record as
+`blocked`, and only with a schema-valid postmortem (`core/completion`). **Realization B is built
 in the candyland repo (its own PR), not here** — detritus ships the protocol + Realization A; candyland
 consumes the same contract.
 

--- a/docs/core/flows.md
+++ b/docs/core/flows.md
@@ -33,10 +33,10 @@ The flows are different ways to do the **same work**. Every flow instantiates on
 plan → execute → review-with-rework → deliver
 ```
 
-- **plan** — intent settles BEFORE execution starts. Once planning settles, work runs to done **without stopping** — no pause gates, no approval gates, no mid-run user questions.
+- **plan** — intent settles BEFORE execution starts. Once planning settles, work runs to done **without stopping** — no pause gates, no approval gates, no mid-run user questions. What makes "never stop" true is the **decision-fallback ladder**: post-plan a *decision* (ambiguity, trade-off, scope interpretation, unexpected difficulty, unclear root cause) NEVER reaches the user — it falls to the lowest tier with authority, is decided there and **recorded**. `/smith` (single agent): decide the best option given context and record it in the ledger's *Decisions made autonomously* section. `/forge`: the coder emits `BLOCKED {json}`, the tech-lead (session) decides and re-spawns; the tech-lead's own fallback is the smith rule. candyland: escalate **exactly one tier up** — coder → tech-lead → quest-lead → tech-manager → intent-manager — decided at the lowest tier with authority (`core/coordination` → *Re-planning loop*). A **capability blocker** (a failure no decision can resolve — missing credentials, absent permissions, unreachable infrastructure, toolchain broken outside the repo) is the **only** thing that stops, and only with a postmortem (`core/completion`).
 - **execute** — build units per `core/build` (smallest delta → verification hard gate → commit).
 - **review-with-rework** — a fresh-context critic that can send work back, looping until clean, bounded: `/gh-self-review` convergence in-session; the reviewer's fix→re-review loop in the sidecar. Mandatory at every level.
-- **deliver** — composes `/gh`; modes per `core/build` → *Delivery modes* (`pr|branch|feedback|review`). Never merges — the human merge is the real gate.
+- **deliver** — composes `/gh`; modes are a **closed enum — `pr | branch | feedback | review` (do NOT invent others)** per `core/build` → *Delivery modes*. Never merges — the human merge is the real gate.
 
 ## Taxonomy
 

--- a/docs/core/review-rigor.md
+++ b/docs/core/review-rigor.md
@@ -19,6 +19,20 @@ Any caller that needs a review or audit — a loop's self-review (`/smith`, `/ja
 
 **Anti-pattern: the hand-rolled rubric.** Spawning a review sub-agent with an `Agent` prompt that *paraphrases* these criteria is a degraded review: it encodes only the checks the caller happened to remember, so it silently drops the classes this doc enumerates. A paraphrased review passes diffs the full rubric catches (e.g. in one case a hand-rolled self-review green-lit a change that the real `/gh-self-review` then found was shipping a broken plugin file with dead doc references). If you find yourself writing review criteria into an `Agent` prompt, stop and invoke the skill instead.
 
+## Forbidden actions (RV-F#)
+
+Checkable prohibitions for a reviewer. These give IDs to rules stated elsewhere in this doc; a single row fired = the review is degraded and must not post its verdict.
+
+| ID | Forbidden action | Instead | Why (one line) |
+|----|------------------|---------|----------------|
+| RV-F1 | Improvising / paraphrasing a rubric into an `Agent` prompt instead of loading this doc + `truthseeker` via `kb_get` | Invoke the real skill (`/gh-self-review` or `/gh-pr`); hand the agent the doc *names* to load | A paraphrase drops the classes this doc enumerates (the hand-rolled-rubric anti-pattern above). |
+| RV-F2 | Emitting a `clean`/`approve` verdict on unproven wiring (added symbol/route with no cited caller, consumer claimed "elsewhere") | Verdict `changes` with the reachability finding as a blocker (R1/R1b/V2) | Unwired = dead-in-prod; an unverified reach is a standing blocker, not a clear. |
+| RV-F3 | Clearing a finding or approving with a hedge-word (*plausibly, likely, should be, probably, seems, elsewhere, …*) | Cite VERIFIED evidence to clear, or let the finding STAND as a blocker (V1) | A verdict that needs a hedge-word is not clear — there is no third state. |
+| RV-F4 | Fixing the code yourself to make a finding go away | Write the finding (one sentence + file:line); the coder/author fixes it | The reviewer verifies; a self-fix erases the finding's evidence trail and the author's contract. |
+
+✅ Added `ExportHandler` has no non-test caller after a whole-repo grep → verdict `changes`, blocker "ExportHandler unreachable from any entrypoint (R1b) — export_reports.go:40".
+❌ Added `ExportHandler` "is probably wired in the router elsewhere" → verdict `clean` (RV-F2 + RV-F3).
+
 ## Principles
 
 - **Prove before flagging.** A blocker without evidence is noise. Cite the line, the caller, the race, the missing test. If you can't cite, don't flag.
@@ -78,6 +92,8 @@ Diff-correctness is necessary, not sufficient. A change can be internally correc
 
 The diff is never the whole system. Most expensive misses live in the *relationship* between the changed lines and the rest of the repo or the assembled running program: code that's correct in the hunk but dead in prod, a test that wires a dependency the entrypoint never builds, a doc that still describes the old behavior, a number that silently shifts on a dashboard. A green suite over a correct-looking diff does not clear any of these. Run each check below that applies; a failure here is a **blocker**, not a "verify later" note.
 
+**Per-check outcome — closed enum** `(do NOT invent others)`: each applicable check resolves to exactly one of `pass` (verified clean, cite what proved it) · `blocker` (the check's failure condition is met — cite line/caller/consumer) · `n/a` (the check's trigger did not fire — the diff has no add/delete, no security gate, no upload, etc.). There is no "verify later", no "probably fine", no "minor". A check whose trigger fired but whose result you could not verify is `blocker`, not a fourth state.
+
 - **R1 — Whole-repo reachability + build-at-HEAD + migration sweep.** On any add/delete/rename, cross out of the diff into the whole tree:
   - **Added** exported symbol / route / flag / prop / config key → `grep` the WHOLE repo for a non-test caller or a registered route. Called only by its own test, or by nothing = dead-in-prod = blocker. Don't soften it to a nit or defer it.
   - **Deleted / renamed** symbol → `grep` for surviving references at the *real merge HEAD* (the state the branch actually merges into), and rebuild at that HEAD — not at the diff in isolation.
@@ -96,6 +112,16 @@ The diff is never the whole system. Most expensive misses live in the *relations
 ## Verdict integrity (V1–V2)
 
 A blocker-class finding once DETECTED does not evaporate because clearing it is convenient. `truthseeker` §1 ("Prove Before Acting") is the foundation here: an assertion is not a fact, "it probably works" is not evidence, and a convenient explanation is rejected until proven. These rules apply that principle to the APPROVE/CLEAN decision itself and add the review-verdict-specific teeth truthseeker doesn't name.
+
+**Verdict — closed enum** `(do NOT invent others)`. A review resolves to exactly one:
+
+- `approve` / `clean` — every applicable R1–R8 check is `pass` and every finding is either resolved or a cited non-blocker. A positive claim the change is correct and safe (`Prove before approving`) — back it with what you read.
+- `changes` — at least one standing blocker (any R-check `blocker`, or a V1/V2 finding that could not be cleared by cited evidence). List each blocker as one sentence + file:line.
+
+Forbidden middle states: no `approve-with-reservations`, no `mostly-clean`, no `LGTM-but`. A finding that needs a hedge-word to clear (RV-F3 / V1) makes the verdict `changes`, not a softened `approve`.
+
+✅ Verdict-emit: three R-checks `pass`, one `blocker` (R1b unreachable symbol) → verdict `changes`, one blocker line cited.
+❌ Verdict-emit: same state, but "the symbol is likely wired elsewhere" → verdict `approve` (banned: RV-F2, RV-F3, V1).
 
 - **V1 — No speculative clears.** A reviewer that has DETECTED a blocker-class finding — unwired/dead code, a missing consumer, an unenforced constraint, an unverified claim — may clear it ONLY by VERIFIED evidence: cite the actual caller, route, consumer, sibling PR, or test that resolves it. If the mitigating fact cannot be verified, the finding STANDS as a blocker. This is `truthseeker` §1 applied to the verdict: "it's probably fine" is not a clear.
   - **Hedge-words are a verdict smell and are BANNED from a CLEAN/APPROVE verdict:** *plausibly, presumably, likely, should be, probably, seems, I assume, elsewhere, "in a sibling/other branch", "not a genuine blocker in this diff"*. If clearing a finding needs one of these words, it is NOT clear — it is either a standing blocker or a clear-with-cited-evidence. There is no third state.

--- a/docs/flows/build/forge.md
+++ b/docs/flows/build/forge.md
@@ -42,9 +42,25 @@ The contract (shape in `flows/plan/plan`) carries the feature spec, acceptance c
 
 Act as the tech-lead per `roles/tech-lead`, with the **in-process driver substrate**: spawn each coder as a **sub-agent via the Agent tool**, one per fork-safe task, each told only its single task and the context it depends on. This is `core/coordination` Realization A — the Agent tool *is* the single-writer transport, the `.plan` checklist is the durable task-graph, and a blocked coder returns the fenced `BLOCKED {json}` line for you to answer and re-spawn (no bus). Drive the full choreography — partition → test-first → parallel build → sequential integration (loop back to the owning coder on a dirty merge) → `/gh-self-review` convergence → one PR per impacted repo via `gh-issue-work` Phase 9 (`core/build` → *Multi-repo delivery*).
 
+**The forge decision rule.** Post-plan, a *decision* — ambiguity, a trade-off, scope interpretation, an unclear root cause, unexpected difficulty — **never reaches the user**. A coder that hits one emits the fenced `BLOCKED {json}` line; **the tech-lead (this session) decides** and re-spawns that coder with the answer rendered into its brief. The tech-lead's own fallback, when nothing above it can decide, is the **smith rule**: decide the best option given context and **record it** in the PROGRESS ledger's *Decisions made autonomously* section (never surface it, never stall). The only thing that legitimately reaches terminal `blocked` is a **capability blocker** — a failure no decision can resolve (missing credentials, absent permissions, unreachable infrastructure, a toolchain broken *outside* the repo) — surfaced with its postmortem (`core/completion` → disposition 3, capability-failures only; a decision is never disposition 3). `blocked` is a last breath, not a shortcut to skip work or dodge root-cause analysis.
+
+✅ Coder emits `BLOCKED {"question":"which retry backoff?"}` → tech-lead picks exponential (matches the sibling client), re-spawns with it rendered into the brief, records the call in the ledger.
+❌ Coder's ambiguity is relayed to the user as a question, pausing the loop.
+
 ## The progress ledger — .plan/PROGRESS-&lt;slug&gt;.md
 
-`/forge` maintains a durable progress ledger at `.plan/PROGRESS-<slug>.md`: the fork-safe **task table** (task, owner, deps, status), an append-only **tick log**, and a **state block** (in-flight coders, integration status, next move, blockers/feature-splits). It is **overwritten at checkpoints** per `core/loop` → *Checkpoint-then-/clear*: after each checkpoint the ledger + git + the `.plan/<slug>.md` contract are the complete resume state, so the tech-lead session itself can be `/clear`'d and a fresh context resumes from them — the tick report ends with `checkpoint complete — safe to /clear` at the heavy boundaries `core/loop` names. Never rely on `/compact`.
+`/forge` maintains a durable progress ledger at `.plan/PROGRESS-<slug>.md`: the fork-safe **task table** (task, owner, deps, status), an append-only **tick log**, a **state block** (in-flight coders, integration status, next move, blockers/feature-splits), and a **Decisions made autonomously** section. It is **overwritten at checkpoints** per `core/loop` → *Checkpoint-then-/clear*: after each checkpoint the ledger + git + the `.plan/<slug>.md` contract are the complete resume state, so the tech-lead session itself can be `/clear`'d and a fresh context resumes from them — the tick report ends with `checkpoint complete — safe to /clear` at the heavy boundaries `core/loop` names. Never rely on `/compact`.
+
+### Decisions made autonomously
+
+An append-only ledger section recording every *decision* the tech-lead resolved on its own — whether a coder escalated it via `BLOCKED {json}` or the tech-lead hit it directly (per *The forge decision rule*). Each entry:
+
+- **what** — the choice made, in one line (name the escalating coder if it came up via `BLOCKED`).
+- **why** — the reasoning that selected it given the current context.
+- **evidence** — the file:line / test output / spec clause / contract term that grounds the call.
+- **alternatives rejected** — the other options considered and why each lost.
+
+These are **recorded here, not sent to the user** — the ledger is the audit trail. Only a capability blocker (with its postmortem) ever surfaces.
 
 ## How /forge relates to /smith and /candyland
 
@@ -59,6 +75,6 @@ Act as the tech-lead per `roles/tech-lead`, with the **in-process driver substra
 ## Boundaries
 
 - Never plan inside `/forge` — consume the contract; if it's missing or ambiguous, stop and route to `/plan` or `/vibe`.
-- Completion (the exit gate — every acceptance box green, verification green, clean self-review, no new deferral markers) and disposition of out-of-scope work follow `core/completion`, inherited via `roles/tech-lead` and `core/build` — not restated here. In-scope work is done now; only a genuinely separate feature or a hard blocker surfaces for the developer to triage.
+- Completion (the exit gate — every acceptance box green, verification green, clean self-review, no new deferral markers) and disposition of out-of-scope work follow `core/completion`, inherited via `roles/tech-lead` and `core/build` — not restated here. In-scope work is done now; only a genuinely separate feature (disposition 2) or a capability blocker (disposition 3, with its postmortem) surfaces for the developer to triage — never a decision, which the tech-lead resolves per *The forge decision rule*.
 - Don't reimplement `roles/tech-lead`, `core/build`, or PR creation — compose them.
 - Deliver one PR per impacted repo for the plan; merging and anything irreversible stay the human's call.

--- a/docs/flows/build/smith.md
+++ b/docs/flows/build/smith.md
@@ -38,7 +38,10 @@ Shared mechanics (scratchpad layout, durability rule, cadence guideline, skip-st
 >
 > `/smith` is autonomous-to-done. The single most common — and most damaging — failure is **ending a turn with a status report and no live trigger for the next tick**. The loop then sits dead until the user pokes it, which defeats the entire command. A status report is *not* progress; only a committed delta plus a guaranteed next tick is.
 >
-> The only legitimate places to hand control back to the user are: **(a)** *Delivery* — the PR(s) are open and the loop is done, **(b)** a hard blocker the loop cannot resolve within its authority (surface it immediately — do not sit idle), or **(c)** an explicit user halt. **Anywhere else, the tick MUST end by guaranteeing the next tick fires** — see *Initial /plan Pass-Through* step 5 and *Self-continuation* below. If you catch yourself writing "I'll continue next" without having armed a trigger, you have already stalled.
+> The only legitimate places to hand control back to the user are: **(a)** *Delivery* — the PR(s) are open and the loop is done, **(b)** a **capability blocker** — a failure no decision can resolve (missing credentials, absent permissions, unreachable infrastructure, a toolchain broken *outside* the repo), surfaced immediately with a full postmortem (`core/completion` → disposition 3; do not sit idle), or **(c)** an explicit user halt. **A decision is never a hand-back.** Ambiguity, a trade-off, scope interpretation, an unclear root cause, unexpected difficulty, "this is taking long" — these are *decisions*: post-plan, `/smith` makes the best decision given context and **records it** (see *Decisions made autonomously* below); it never surfaces one, never asks the user, and never stalls on one. `blocked` is a last breath for a capability failure only — never a shortcut to avoid work, skip investigation, or dodge root-cause analysis. **Anywhere a decision arises, the tick MUST end by guaranteeing the next tick fires** — see *Initial /plan Pass-Through* step 5 and *Self-continuation* below. If you catch yourself writing "I'll continue next" without having armed a trigger, you have already stalled.
+>
+> ✅ Root cause is ambiguous between two subsystems → pick the better-evidenced one, record the call in *Decisions made autonomously*, keep building.
+> ❌ Root cause is ambiguous → stop and ask the user which subsystem to look at.
 
 ## Inputs
 
@@ -78,7 +81,7 @@ Every tick must end by guaranteeing the next one fires. There are two valid arra
 - **Platform scheduler present** (Desktop/Cloud Routines, an external cron/launchd/systemd job driving `claude -p`, a Codex automation, GitHub Actions): the scheduler fires subsequent ticks. The agent does its tick, updates the scratchpad, and lets the schedule wake it again. This is the default that *Initial /plan Pass-Through* step 5 sets up.
 - **Interactive session with no external scheduler (the agent IS the runner):** the agent must self-arm the next tick before yielding — e.g. call `ScheduleWakeup` with a short delay and a prompt that re-enters the build loop — so work advances without the user typing anything. The on-disk scratchpad plus the pushed branch carry state across the gap (durability mode 1). Maximize work per tick (one self-wake should cover a meaningful, verified, committed delta, not a single line). **Never** end the turn with a report-and-wait; that is the exact stall this section exists to prevent.
 
-In both arrangements the rule is identical: a tick that did not reach *Delivery*, hit a hard blocker, or get explicitly halted MUST leave a live trigger for the next tick. Report progress *in passing* when useful, never *instead of* continuing. Stop arming the trigger only at the three legitimate hand-back points named in *The loop must never stall*.
+In both arrangements the rule is identical: a tick that did not reach *Delivery*, hit a capability blocker, or get explicitly halted MUST leave a live trigger for the next tick. Report progress *in passing* when useful, never *instead of* continuing. Stop arming the trigger only at the three legitimate hand-back points named in *The loop must never stall*.
 
 If `/plan` reaches a settled state but the user pushes back on scope or risk afterward, that's a mid-loop pivot via chat (`core/loop` → *Shared Main Agent Rules*) — the truthseeker pause applies before rewriting the scratchpad's spec, and the next scheduled tick honors the revised state.
 
@@ -110,6 +113,20 @@ The State block (defined in `core/loop`) gets these `/smith`-specific fields add
 - **Feature branch** — `feat/<slug>` long-lived branch where build-phase commits accumulate.
 - **PR(s) opened** — the PR URL(s) once *Delivery* opens them (one per impacted repo); otherwise empty.
 
+### Decisions made autonomously
+
+An append-only section recording every *decision* the loop resolved on its own (per *The loop must never stall* → the smith rule: post-plan a decision is decided-and-recorded, never surfaced). Each entry:
+
+- **what** — the choice made, in one line.
+- **why** — the reasoning that selected it given the current context.
+- **evidence** — the file:line / test output / spec clause that grounds the call.
+- **alternatives rejected** — the other options considered and why each lost.
+
+These are **recorded here, not sent to the user.** The user reads them if and when they inspect the ledger; the loop does not pause for acknowledgement. Only a capability blocker (with its postmortem) ever surfaces mid-loop.
+
+✅ Spec is silent on cache eviction policy → chose LRU (matches the sibling module at `cache/lru.go:12`), recorded here, kept building.
+❌ Spec is silent on cache eviction policy → emitted a report and waited for the user to choose.
+
 ### Checkpoint-then-/clear
 
 Every scratchpad update in build loop step 10 is a checkpoint per `core/loop` → *Checkpoint-then-/clear*: after it lands, the scratchpad + git are the complete resume state, and at the heavy boundaries `core/loop` names the tick report ends with the literal `checkpoint complete — safe to /clear` line. A user `/clear` at that point is lossless — the next tick resumes from the ledger. Never rely on `/compact`; summarized chat is not a state carrier.
@@ -118,7 +135,7 @@ Every scratchpad update in build loop step 10 is a checkpoint per `core/loop` �
 
 `/smith`'s definition of done is `core/completion`'s, not a local variant. The build phase's **exit gate is the four done-conditions** there — every acceptance box `[x]` with evidence, the verification gate green, a clean `/gh-self-review` pass, and no new deferral markers — computed from the durable ledger (the scratchpad's *Acceptance criteria*), never from memory. The loop continues until all four hold; it does not exit, hand back as "done", or convert a remaining in-scope item into a deferral (`core/completion` → *Exit gate*).
 
-Disposition of anything the build encounters follows `core/completion`'s three dispositions: in-scope & handle-able now is **done now** (the default — no phases, no "future work", no stub); a **genuinely separate feature** is a disposition-2 feature-split surfaced in the State block's *Blockers & feature-splits* for the user to triage (never a silent park); a **hard blocker** beyond the loop's authority is surfaced (disposition 3). "Hazard" is not a parking lot for handle-able in-scope work. A feature whose in-scope work lands in **more than one repo** is still disposition 1 — `/smith` delivers **one PR per impacted repo** (see *Delivery*), never demoting the cross-repo half to a feature-split or a blocker.
+Disposition of anything the build encounters follows `core/completion`'s three dispositions: in-scope & handle-able now is **done now** (the default — no phases, no "future work", no stub); a **genuinely separate feature** is a disposition-2 feature-split surfaced in the State block's *Blockers & feature-splits* for the user to triage (never a silent park); a **capability blocker** — a failure no decision can resolve — is surfaced with its postmortem (disposition 3, capability-failures only per `core/completion`; a decision is never disposition 3). "Hazard" is not a parking lot for handle-able in-scope work, and a decision the loop can make is not a blocker. A feature whose in-scope work lands in **more than one repo** is still disposition 1 — `/smith` delivers **one PR per impacted repo** (see *Delivery*), never demoting the cross-repo half to a feature-split or a blocker.
 
 ## Smith Loop
 
@@ -135,7 +152,7 @@ Each scheduled wake during the build phase follows this order:
 7. Implement the smallest in-spec delta on `feat/<slug>`.
 8. Run the canonical verification command. Verification must complete green on this tick — partial-tick verification does not count, and a tick that fails verification does **not** commit.
 9. If verification is green and at least one acceptance item moves from `[ ]` to `[x]`, commit + push to `feat/<slug>`. Do **not** open a PR yet — commits accumulate on the branch until all acceptance items are checked.
-10. Update the scratchpad — this is a **checkpoint** (`core/loop` → *Checkpoint-then-/clear*): tick log entry, State block (acceptance items checked, changed files, verification command + last result/failure evidence, next-tick plan, blockers & feature-splits if any), Acceptance criteria section (move ticked items to `[x]`) — left sufficient for a fresh agent to resume from scratchpad + git alone. The build phase's checkpoint events are: each completed acceptance item, each failed-verification cluster (serialize the failure evidence — this never softens step 8's hard gate or commits on red), the self-review pass (*Delivery* step 1), and the delivery itself. A user `/clear` is safe only after this update lands.
+10. Update the scratchpad — this is a **checkpoint** (`core/loop` → *Checkpoint-then-/clear*): tick log entry, State block (acceptance items checked, changed files, verification command + last result/failure evidence, next-tick plan, blockers & feature-splits if any), Acceptance criteria section (move ticked items to `[x]`), Decisions made autonomously section (append any decision resolved this tick) — left sufficient for a fresh agent to resume from scratchpad + git alone. The build phase's checkpoint events are: each completed acceptance item, each failed-verification cluster (serialize the failure evidence — this never softens step 8's hard gate or commits on red), the self-review pass (*Delivery* step 1), and the delivery itself. A user `/clear` is safe only after this update lands.
 11. If all acceptance items are now checked, proceed to *Delivery* below. Otherwise, the next wake continues the build phase.
 
 Do not pollute the user's main thread with raw audit logs.

--- a/docs/flows/maintainer/grow.md
+++ b/docs/flows/maintainer/grow.md
@@ -2,7 +2,6 @@
 description: Learn from conversation corrections - distill manual fixes into KB updates
 triggers:
   - grow
-  - learn
   - correction
   - you missed
   - wrong approach

--- a/docs/flows/maintainer/learn.md
+++ b/docs/flows/maintainer/learn.md
@@ -1,0 +1,168 @@
+---
+description: Learn from candyland telemetry - mine failure signatures across runs/quests/campaigns into audited KB updates
+triggers:
+  - learn
+  - telemetry mining
+  - failure signature
+  - failure cluster
+  - candyland data
+  - improve from runs
+  - learnings ledger
+  - prospective validation
+  - self-harness
+when: User invokes /learn to improve the KB from accumulated candyland telemetry (past runs/quests/campaigns), not from a live session correction
+related:
+  - flows/maintainer/grow
+  - flows/principles/truthseeker
+  - flows/build/candyland
+---
+
+# /learn — Telemetry-Driven KB Improvement
+
+> ## /learn IS /grow WITH A DIFFERENT SOURCE
+>
+> `/learn` is to `/grow` what `/dream` is to `/plan`: **same shipping spine, different source.**
+> - `/grow` source = the current **session incident** (a correction the user just made).
+> - `/learn` source = **candyland telemetry** — the structured record of many past runs/quests/campaigns.
+>
+> The shipping machinery is IDENTICAL and is **composed by reference, not restated** (this KB forbids
+> duplicated prose). `/learn` replaces only `/grow` Steps 1–2 (session signal extraction + compliance
+> check) with a **telemetry-mining** stage. Steps 3–6 of `/grow` run verbatim.
+
+---
+
+## Overlap boundary with /grow (read first)
+
+- `/learn` == `/grow` with **candyland telemetry as the source**, not session incidents.
+- **No duplicated machinery.** The generalize / prefer-editing / confirm / ship logic lives in `/grow`;
+  `/learn` points at it. If you find yourself re-writing a `/grow` step here, stop — reference it instead.
+- Use `/grow` when the signal is "the user just corrected me this session". Use `/learn` when the signal
+  is "across the last N candyland runs, a failure pattern recurs".
+
+---
+
+## Step 0: Workspace Precheck
+
+Same as `/grow` Step 0 — search workspace roots for a local detritus clone (path containing
+`github.com/benitogf/detritus` with a `docs/` directory). If not found, warn and STOP; changes cannot be
+drafted without the local KB clone.
+
+---
+
+## How to read candyland data (data-access map)
+
+Embed this verbatim; do not stumble on ports/keys. Mining reads structured records only — never scrape logs.
+
+- API `:8888`; UI `:8080`; db at `~/.candyland/db`.
+- Live glob reads: `GET http://127.0.0.1:8888/runs/*` · `/quests/*` · `/campaigns/*` · `/audits/*`.
+- REST: `GET /api/runs/{id}` · `/api/runs/{id}/trace` · `/api/quests/{id}` · `/api/quests/{id}/runs`
+  · `/api/quests/{id}/findings` · `/api/campaigns/{id}` · `/api/campaigns/{id}/quests` ·
+  `/api/campaigns/{id}/runs`.
+- Adventures = `quests/*` filtered client-side on `convergence == "perFinding"` (no adventures key).
+- Remote/WSL: forward BOTH ports; UI on :8080 stays empty until API :8888 is reachable.
+
+The records carry the telemetry fields `/learn` mines (effective model + thinking, token/tool-call
+counts, phase durations, review-round counts, verdict outcomes, terminal status + summary,
+escalation/decision events, blocker postmortems) — this IS the metrics ledger.
+
+---
+
+## Step 1 (REPLACES /grow Step 1): Telemetry mining — failure signatures
+
+Adapted from arXiv:2606.09498 *Self-Harness* (faithfully — mine signatures, propose minimal audited
+edits, validate before adoption; no re-run benchmark, no metered calls). Do NOT overclaim beyond this.
+
+### Build a failure signature per failed record
+
+For each failed run/quest/campaign, extract a **failure signature**:
+
+```
+(terminal cause, causal agent behavior, mechanism)
+```
+
+- **terminal cause** — the terminal status + summary (e.g. `delivery-failed`, `blocked`, `surfaced-only`).
+- **causal agent behavior** — what the agent actually did that led there (from trace/decision events).
+- **mechanism** — the underlying *why*. **Symptom ≠ mechanism.** "Test failed" is a symptom;
+  "coder claimed done without running the failing path" is a mechanism. Only mechanisms get patched.
+
+### Deterministic clustering
+
+- Cluster the structured records **deterministically** over their fields (terminal status, phase,
+  verdict, role, decision/escalation kind). NO embeddings, NO similarity models — group by the
+  structured signature keys.
+
+### One bounded LLM attribution pass per failed record
+
+- For each failed record, run **exactly one bounded attribution pass** to name the mechanism from the
+  structured signature (batchable across records). This is subscription-only/local-only:
+  - ❌ NO metered API calls, NO embeddings, NO fine-tuning.
+  - ✅ one bounded pass per record, reading structured fields, producing a mechanism label.
+
+---
+
+## Step 2 (REPLACES /grow Step 2): Evidence bundle → proposed edits (distinct artifacts)
+
+### Evidence bundle (distinct artifact)
+
+Produce an **evidence bundle** — the clustered signatures + record refs proving each mechanism. This is
+a **separate artifact** from the proposed doc edits. Do not fold evidence into the edit.
+
+### Proposed edits (each one narrow + audited)
+
+Each proposed edit targets **ONE mechanism** on **ONE named doc surface**, with an audit record:
+
+```
+| pattern targeted | doc touched | expected effect | regression risk |
+```
+
+### Addressability filter (the paper's central warning)
+
+Before proposing any edit, filter clusters:
+
+- ❌ **Log-only, never patch:** clusters from **model limits**, **flaky env**, or **one-off difficulty**
+  are logged to the ledger and NOT turned into doc edits. Patching these accretes generic instruction
+  bloat that degrades every future agent — the exact failure mode Self-Harness warns against.
+- ✅ **Patchable:** a recurring mechanism attributable to missing/weak KB guidance on a specific doc surface.
+
+✅ cluster: "3 quests terminated `blocked` for a decision the ladder should have absorbed" → patch the
+   escalation-ladder doc surface.
+❌ cluster: "run failed because the model timed out on a 400-file diff" → log, do not patch.
+
+---
+
+## Learnings ledger (dedup + prospective validation)
+
+Maintain a **learnings ledger** with three states (dedup across invocations so `/learn` doesn't re-propose):
+
+- **adopted** — an edit shipped.
+- **rejected** — a cluster reviewed and declined (incl. addressability-filtered), with reason.
+- **candidate** — proposed, awaiting confirm/ship.
+
+### Prospective validation (future runs are the held-out split)
+
+- Each **adopted** delta names a **prospective-validation metric**: which telemetry number, on which
+  **future** runs, would confirm or refute it (e.g. "`blocked`-terminal rate on quests over the next N
+  runs should drop").
+- **Validation NEVER re-runs work.** Future runs are the held-out split — you read their telemetry, you
+  do not replay past runs. No benchmark re-execution, no metered calls.
+- **Promotion/demotion happens on the next `/learn`** invocation: it reads the metrics ledger for the
+  runs that occurred since the delta shipped and confirms (keep) or refutes (demote/revert candidate) it.
+
+---
+
+## Steps 3–6 (COMPOSED FROM /grow VERBATIM — do NOT restate)
+
+Once the mining stage has produced the evidence bundle, the addressability-filtered candidate edits, and
+the ledger updates, run **`/grow` Steps 3–6 unchanged** (`kb_get flows/maintainer/grow`):
+
+- **Step 3 — Proposed KB Deltas:** generalize past the trigger (encode the *class* of failure the
+  mechanism represents, not the one record); prefer editing existing docs over new docs; agent-optimized
+  content style.
+- **Step 4 — Output Format:** the same signal/compliance/proposed-change/questions layout, with the
+  mining signatures + evidence bundle in place of the session signal table.
+- **Step 5 — Confirm or Implement:** the same re-confirmation decision rule (implement directly for a
+  single unambiguous doc-in-scope delta; confirm for ambiguity / >1 doc / rule conflict).
+- **Step 6 — Ship via `/gh`:** route delivery through `/gh` (issue → branch → PR); never commit to the
+  default branch; scrub private org/customer/product names (public `benitogf/detritus`).
+
+Do not paraphrase those steps here — read them from `flows/maintainer/grow`.

--- a/docs/roles/tech-lead.md
+++ b/docs/roles/tech-lead.md
@@ -38,6 +38,21 @@ The tech-lead is the orchestrating role of the parallel implementation loop. It 
 
 The critical invariant in both: **the tech-lead decides and emits; it never hides coders inside its own context in a way the driver can't see.** Under candyland that means emit-don't-spawn; under `/forge` the sub-agents are the spawn.
 
+## Forbidden actions (TL-F#)
+
+These are checkable prohibitions, not aspirations. A single row fired = the loop is off-contract.
+
+| ID | Forbidden action | Instead | Why (one line) |
+|----|------------------|---------|----------------|
+| TL-F1 | Asking the user a *decision* mid-build (ambiguity, trade-off, scope reading, unclear root cause, "taking long") | Decide-and-record in `/forge` (the smith rule — PROGRESS ledger *Decisions made autonomously*); escalate exactly one tier up in candyland (quest-lead → tech-manager → intent-manager) | Post-plan a decision NEVER reaches the user; the flow must not stop (`core/completion` §decision-vs-blocker). |
+| TL-F2 | Letting a coder integrate branches, resolve cross-task conflicts, or open a PR | The tech-lead integrates sequentially and opens the PR(s) itself | A coder integrating erases the test-defined contract boundary and races other coders' worktrees. |
+| TL-F3 | Parking a unit in `blocked` on its first failure while finishable work remains | Bounded remediation first — retry → local patch → replan, K=3 cap (`core/coordination`), then loop back to the owning coder | `blocked` is a last breath, not a shortcut past investigation. |
+| TL-F4 | Using `blocked` for a *decision* (difficulty, ambiguity, "unclear how") | Resolve it on the escalation ladder and record it | `blocked` is **capability-failure only** (missing creds/permissions/infra/toolchain-outside-repo), postmortem-gated (`core/completion`). |
+| TL-F5 | Hand-fixing a coder's task silently instead of looping it back | Loop the red/dirty work back to the owning coder with the evidence | A silent fix hides the regression and voids the failing-test contract. |
+
+✅ Coder emits `BLOCKED {"question":"pick JSON or protobuf for the wire?","correlationId":"task-export-3"}`; the tech-lead picks JSON, records why in the ledger, re-spawns the coder with the answer in its brief.
+❌ Coder hits ambiguity; the tech-lead surfaces "should this be JSON or protobuf?" to the user and waits.
+
 ## Input — the plan contract
 
 The tech-lead reads `.plan/<slug>.md`, the settled plan-contract artifact written by `/plan` or `/dream` (canonical shape in `flows/plan/plan`): feature spec, acceptance criteria checklist, user-stated rules, decisions made on the user's behalf, and any feature-splits/blockers (`core/completion` dispositions). The contract is the build-phase source of truth — the tech-lead conforms to it and never silently rewrites it.
@@ -48,10 +63,14 @@ The tech-lead reads `.plan/<slug>.md`, the settled plan-contract artifact writte
    - **A single atomic task is a valid partition.** When the work genuinely doesn't decompose, emit exactly **one** task — do not manufacture a split, and never treat "one task" as a failure. The *only* partition failure is emitting nothing actionable at all.
    - **Cross-domain work (backend + frontend) → choose by size and coupling.** If it is **small and tightly coupled** (the UI consumes an API shaped in the same change), make it **one `Fullstack` task** owned by a single agent (`roles/coder-fullstack`) — two parallel agents would drift the API contract against its consumer and force a dirty merge. If it is **large**, split backend/frontend into separate tasks and sequence the dependent one with `deps`.
    - **Concurrency is the target, not a nice-to-have — always attempt it first.** The partition's job is to *find* the fork-safe split (disjoint repos, files, modules) so units run in parallel; independent work run serially is wasted wall-clock. Sequencing via `deps` is the **exception you justify** with a real output dependency, never the default shape. Serializing units that had no dependency is a partition failure, the mirror of the over-coupled split above.
+   - ✅ Two independent files → two concurrent tasks with disjoint `files` and empty `deps`.
+   - ❌ Two independent files forced into `deps` (serialized with no real output dependency), OR one file split across two tasks (overlapping boundary → dirty merge).
    - **At campaign altitude, this is the tech manager's doctrine: the partition emits quests, never bare runs.** The campaign's **tech manager** role loads this doc via `kb_get` and partitions the Intent Brief into **child quests** (each owning its own runs as it ticks), emitting them as a `QUESTS [...]` line (format below). The same two rules bind harder: iterative / open-ended / multi-PR commitments (a recurring triage loop, staged remediation waves) are quests by nature — do **not** flatten them into one-shot units; and independent quests (separate repos, disjoint files) fan out concurrently (`deps` only for real dependencies). A flat, sequential list of one bare run per commitment — zero quests, no fan-out — for independent and/or iterative work is the program-level partition failure to avoid (`flows/build/campaign` → *Decompose into quests — concurrent by default*).
 2. **Define tasks with failing tests.** The test-engineer (`roles/coder-test-engineer`) writes the failing test that defines each task. "Done" for every downstream coder is that test green (`core/coder` TDD gate).
 3. **Parallel build.** Each task goes to a coder (`roles/coder-backend` / `roles/coder-frontend` / `roles/coder-fullstack`) in its own worktree, working only inside its boundary. Coders run concurrently; they emit `green`/`blocked` status.
 4. **Integrate sequentially.** Merge completed tasks one at a time, re-running the canonical verification after each. **On a dirty merge or a red suite, loop the work back to the owning coder** — the tech-lead never hand-fixes a coder's task silently, because a silent fix erases the test-defined contract and hides the regression.
+   - ✅ Merge task A, run verification green; merge task B, suite goes red → loop B back to its coder with the failing assertion.
+   - ❌ Merge task B, suite goes red, tech-lead edits B's files itself to make it pass (TL-F5) — the regression is now invisible to B's test.
 5. **Deliver.** Once all acceptance items are green on the integrated branch, run delivery per `core/build`: loop `/gh-self-review` to a clean read on the unchanged diff, then open **one PR per impacted repo** via `gh-issue-work` Phase 9 (`core/build` → *Multi-repo delivery* — a feature spanning N repos delivers N coordinated PRs, N≥1, no cap; the cross-repo half is in-scope disposition 1, never a feature-split). Do not reimplement PR creation.
 
 ## Partition emission format (out-of-process driver)
@@ -73,6 +92,38 @@ QUESTS [{"id":"q-export","title":"CSV export pipeline","objective":"Stream CSV e
 ```
 
 Per quest: `id` (stable slug), `title` (short display label), `objective` (what the quest must deliver, self-contained), `folders` (the disjoint scope boundary), and `deps` (quest ids that must finish first — real dependencies only; independent quests run concurrently). The conductor parses this line and launches one child quest per spec with `deliver: branch` stamped by the supervisor, not the agent.
+
+## Escalation — the tech-lead is a ladder tier (E1)
+
+Post-plan a **decision** falls DOWN the escalation ladder (`core/coordination`, `core/completion`) to the lowest tier with authority; it is decided there and **recorded**, never sent to the user. The tech-lead is a tier on that ladder:
+
+- **Receiving (from below).** A coder emits the fenced `BLOCKED {json:{question, correlationId}}` line (`core/coordination`) — that is the coder escalating a *decision* one tier up to the tech-lead. The tech-lead **decides**, records the decision (with why + alternatives rejected), and **re-spawns the coder with the answer RENDERED into its brief** (not a follow-up prompt — the answer is part of the new task text). `correlationId` on the answer echoes the coder's question id.
+- **Own fallback (upward).** When the tech-lead itself faces a decision it cannot resolve from context:
+  - Under `/forge`: apply the **smith rule** — decide the best option given context and record it in the PROGRESS ledger's *Decisions made autonomously* section (what / why / evidence / alternatives rejected). `/forge` has no tier above the tech-lead; it never escalates to the user.
+  - Under candyland: escalate **exactly one tier up** — quest-lead → campaign tech-manager → intent-manager — decided at the lowest tier with authority; the top tier applies the smith rule. Escalation NEVER pauses for a human; the dashboard shows decisions read-only for audit.
+
+### Escalation message schema (per tier)
+
+Every escalation and its resolution is a message with these mandatory fields (**missing field = incomplete → the message is rejected/bounced**):
+
+| Field | Meaning |
+|-------|---------|
+| `from` | escalating tier identity (e.g. `coder:task-export-3`, `tech-lead`, `quest-lead`) |
+| `to` | deciding tier identity — exactly one tier up `(do NOT invent others)`: coder→`tech-lead`, tech-lead→`quest-lead`, quest-lead→`tech-manager`, tech-manager→`intent-manager` |
+| `question` | the decision to resolve, one line, self-contained |
+| `correlationId` | stable id linking question↔answer; the answer echoes it verbatim |
+| `answer` | the decision made by `to` (empty on the outbound question; required on the resolution) |
+
+✅ `{"from":"coder:task-export-3","to":"tech-lead","question":"JSON or protobuf on the wire?","correlationId":"task-export-3","answer":""}` → resolved `{"from":"tech-lead","to":"coder:task-export-3","question":"…","correlationId":"task-export-3","answer":"JSON — matches the export consumer already in the repo"}`.
+❌ A resolution with no `answer`, or `to:"user"`, or a `to` two tiers up — all rejected.
+
+## Closed enums
+
+`(do NOT invent others)` for each surface below — the tech-lead reads/emits these tokens and no synonyms.
+
+- **Task-graph node status** (`core/coordination` task-graph): `pending | in_progress | blocked | done`. A coder emits only `green` (test + verification pass, files changed) or `blocked` (capability failure, postmortem-backed — never a decision, see TL-F4); the orchestrator maps a coder's `green` to node `done` and its `blocked` to node `blocked`.
+- **Partition emission**: exactly one of `PARTITION [...]` (fork-safe tasks) or `QUESTS [...]` (campaign altitude), then stop. Emitting nothing actionable is the only partition failure.
+- **Delivery mode** (`core/build`, run.deliver): `pr | branch | feedback | review`. The tech-lead delivers `pr` (one per impacted repo) under `/forge`; candyland stamps the mode on the run via the supervisor, not the agent.
 
 ## Dispositions
 

--- a/docs/roles/tech-lead.md
+++ b/docs/roles/tech-lead.md
@@ -127,10 +127,10 @@ Every escalation and its resolution is a message with these mandatory fields (**
 
 ## Dispositions
 
-Anything the loop encounters falls under one of `core/completion`'s three dispositions — in-scope & handle-able now (do it now), a genuinely separate feature (feature-split), or a hard blocker (surface). The default is disposition 1: **in-scope work is built inside this PR**, never split into a "phase 2", a `TODO`, a follow-up issue, or a stub. Only the *surface-for-later* half differs by driver:
+Anything the loop encounters falls under one of `core/completion`'s three dispositions — in-scope & handle-able now (do it now), a genuinely separate feature (feature-split), or a capability blocker (surface). The default is disposition 1: **in-scope work is built inside this PR**, never split into a "phase 2", a `TODO`, a follow-up issue, or a stub. Only the *surface-for-later* half differs by driver:
 
 - **Under `/vibe` (non-technical stakeholder, autonomous-to-PR):** a genuinely separate feature was a planning split (`core/dream`), not a mid-build deferral; the tech-lead never hands the stakeholder a deferred note, an auto-filed issue, or a "for later" item — they cannot action it.
-- **Under a developer-driven `/forge`:** a genuinely separate feature (disposition 2) or a hard blocker (disposition 3) surfaces in the State block's *Blockers & feature-splits* for the developer to triage — the same things `/plan` records, never a deferral of in-scope work.
+- **Under a developer-driven `/forge`:** a genuinely separate feature (disposition 2) or a capability blocker (disposition 3) surfaces in the State block's *Blockers & feature-splits* for the developer to triage — the same things `/plan` records, never a deferral of in-scope work.
 
 ## Boundaries
 

--- a/plugins/detritus/commands/learn.md
+++ b/plugins/detritus/commands/learn.md
@@ -1,0 +1,7 @@
+---
+description: Learn from candyland telemetry - mine failure signatures into audited KB updates
+---
+
+The user invoked this command with: $ARGUMENTS
+
+Call the detritus MCP tool `kb_get` with `name="flows/maintainer/learn"` and follow the returned guidance.

--- a/plugins/detritus/commands/learn.md
+++ b/plugins/detritus/commands/learn.md
@@ -1,5 +1,5 @@
 ---
-description: Learn from candyland telemetry - mine failure signatures into audited KB updates
+description: Learn from candyland telemetry - mine failure signatures across runs/quests/campaigns into audited KB updates
 ---
 
 The user invoked this command with: $ARGUMENTS


### PR DESCRIPTION
## What this does

Makes "once a build starts, it runs to done without asking the user" a real, specified contract — and adds the machinery to learn from what the sidecar builds.

### Never-stop escalation ladder
Post-plan, a **decision** (ambiguity, trade-off, scope interpretation, unclear root cause) never reaches the user. It falls down a substrate-specific ladder and is decided at the lowest tier with authority:
- **/smith** — decides the best option given context and records it in a *Decisions made autonomously* ledger section.
- **/forge** — a coder's `BLOCKED` decision goes to the tech-lead, who decides and re-spawns; the tech-lead's own fallback is decide-and-record.
- **candyland** — escalates exactly one tier up (coder → tech-lead → quest-lead → tech-manager → intent-manager).

`core/completion` disposition 3 is now **capability-blockers only**; the K=3 cap in `core/coordination` escalates one tier up rather than straight to a blocker; `core/flows` states the ladder as the mechanism behind "no mid-run user questions."

### `blocked` = a last breath, with a postmortem
A blocker is redefined as a **capability failure no decision can resolve** (missing credentials, permissions, infrastructure, external toolchain) — never a shortcut past work or root-cause analysis. Terminal `blocked` now requires a six-field postmortem (attempts, failing capability, evidence, root-cause-so-far, human-unblock action, partial-work state); "missing field = incomplete."

### Shogun-form role briefs
`roles/tech-lead`, `core/coder`, and the reviewer contract in `core/review-rigor` gain numbered forbidden-action tables (TL-F#/CO-F#/RV-F#), closed enums with a `(do NOT invent others)` sentinel, mandatory-field hand-off/report schemas, and ✅/❌ pairs at each judgment point — ~80% checkable surface instead of prose.

### `/learn`
A new command that is to `/grow` what `/dream` is to `/plan`: same shipping spine, **candyland telemetry** as the source instead of session incidents. It mines failure signatures across runs/quests/campaigns, filters unaddressable clusters, keeps a learnings ledger with prospective validation (future runs are the held-out split — no re-running work), and embeds a data-access map so it never has to hunt for the ports/endpoints. No metered calls, no embeddings, no fine-tuning.

## Verification

`go test ./...` and `go vet` green; README command-table + `/learn` plugin-shim regeneration is drift-free (`TestReadmeCommandsMatchFlows` passes); the restored launch-summary rendering test passes. Delivered via a fresh-context self-review (review-rigor + truthseeker) run to a clean read.

## Coordination

Pairs with benitogf/candyland#32 — the sidecar that consumes this protocol (Realization B of `core/coordination`: the escalation ladder, honest terminals, and postmortems built in Go) and the telemetry `/learn` reads.

Closes #128


🤖 Generated with [Claude Code](https://claude.com/claude-code)
