### PR TITLE
refactor(babysit): rename /gh-merge-loop to /babysit

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ and intentionally absent — they are not commands.
 
 | Command | Use it for |
 | --- | --- |
+| `/babysit` | Watch a single PR on an interval — fix any review feedback via /gh-feedback-work, and merge once an approval lands on the latest commit. |
 | `/gh` | Router for GitHub issue/PR workflows — reads conversation context and dispatches to gh-issue-create, gh-issue-work, gh-feedback-work, gh-self-review, or gh-pr. |
 | `/gh-feedback-work` | Address open review feedback on a PR, push fixes, and update the PR body in place — never posts issue/PR comments. |
 | `/gh-issue-create` | Draft a GitHub issue from the current conversation, confirm with the user unless the post was already directed, post it with the Claude Code attribution footer, then offer next steps (/gh-issue-work, refine, or leave). |
 | `/gh-issue-work` | Take a GitHub issue end-to-end — branch, fix, test, commit, push, self-review the diff, confirm with the user unless opening the PR was already directed, then open PR with a product-focused summary and the Claude Code attribution footer. |
-| `/gh-merge-loop` | Watch a single PR on an interval — fix any review feedback via /gh-feedback-work, and merge once an approval lands on the latest commit. |
 | `/gh-pr` | Hard-review a GitHub PR under truthseeker rigor — verify the PR's own claims, hunt for fragility, demand evidence before flagging OR approving, and post an APPROVE or REQUEST_CHANGES review via `gh api`. |
 | `/gh-pr-safe` | Hard-review a posted GitHub PR with the same truthseeker rigor as /gh-pr and auto-post an APPROVE or REQUEST_CHANGES review, but never mutate the working tree of the clone it runs from. |
 | `/gh-self-review` | Deep self-audit of pending local changes (committed + uncommitted) under truthseeker rigor before commit/push/PR. |

--- a/docs/flows/github/babysit.md
+++ b/docs/flows/github/babysit.md
@@ -1,7 +1,9 @@
 ---
 description: Watch a single PR on an interval — fix any review feedback via /gh-feedback-work, and merge once an approval lands on the latest commit. Terminating loop; merge is the exit.
 triggers:
-  - gh-merge-loop
+  - babysit
+  - babysit pr
+  - babysit this pr
   - watch pr
   - watch this pr
   - merge when approved
@@ -18,7 +20,7 @@ related:
   - core/janitor-platforms
 ---
 
-# /gh-merge-loop — Watch a PR Until Merged
+# /babysit — Watch a PR Until Merged
 
 A watch-until-merge loop over **one** PR. Each tick re-checks the PR; if a reviewer posted feedback after the last commit, it fixes it (push + body rewrite); once an `APPROVED` review covers the current HEAD and the PR's `mergeable_state` is `clean` (or `has_hooks`), it merges and stops.
 

--- a/docs/flows/github/gh.md
+++ b/docs/flows/github/gh.md
@@ -15,7 +15,7 @@ related:
   - flows/github/gh-feedback-work
   - flows/github/gh-self-review
   - flows/github/gh-pr
-  - flows/github/gh-merge-loop
+  - flows/github/babysit
 ---
 
 # /gh — Router for GitHub Issue & PR Workflows
@@ -70,7 +70,7 @@ Apply the first matching rule:
 | URL / ref resolves to an **open PR** carrying an unaddressed **CHANGES_REQUESTED** review — a reviewer named concrete findings at/after the current head — **even if the user says "review"** | `gh-feedback-work` — address the reviewer's stated findings. You do NOT run a fresh self-review "past" a posted blocker: a self-review that returns *clean* while an open review says *blocked* is incoherent. Fix what the reviewer named, then push. |
 | URL / ref resolves to an **open PR**, AND user text suggests reviewing it — phrases like "review pr", "review this pr", "code review", "hard review", "review pull request" | `gh-pr` |
 | URL / ref resolves to an **open PR** with comments posted after the PR's last commit, no review-intent text | `gh-feedback-work` |
-| URL / ref resolves to an **open PR**, AND user text wants it watched until merged — phrases like "watch this pr to merge", "keep checking the pr until merged", "merge when approved", "babysit this pr", "/gh-merge-loop" | `gh-merge-loop` |
+| URL / ref resolves to an **open PR**, AND user text wants it watched until merged — phrases like "babysit this pr", "watch this pr to merge", "keep checking the pr until merged", "merge when approved", "/babysit" | `babysit` |
 | URL / ref resolves to an **open PR** with no post-last-commit comments and no review-intent text | Ask: review the PR with `gh-pr`, force-run `gh-feedback-work` anyway, or cancel. |
 | URL / ref resolves to an **open issue** | `gh-issue-work` |
 | URL / ref resolves to a **closed issue or merged/closed PR** | STOP and ask the user whether to reopen, reference it in a new issue, or abandon. Do not silently dispatch. |
@@ -101,7 +101,7 @@ gh api repos/<owner>/<repo>/pulls/<n>/reviews --jq '[.[]|select(.state=="APPROVE
 
 Call the selected sub-skill with the resolved context (repo, issue/PR number, original user prompt, any extracted SHA). Do NOT re-do phases the sub-skill will re-do — let the sub-skill fetch the issue/PR body itself. The router's only job after classification is to hand the sub-skill a clean entry point.
 
-`gh-merge-loop` is the **loop variant**: the router still hands off exactly once, but that single hand-off is a long-running loop that owns its own per-tick lifecycle and delivery (it internally dispatches `/gh-feedback-work` each tick and performs the merge) rather than the usual one-shot "hand off and report." This is one hand-off whose lifecycle lives in the sub-skill — not the router accumulating state across calls.
+`babysit` is the **loop variant**: the router still hands off exactly once, but that single hand-off is a long-running loop that owns its own per-tick lifecycle and delivery (it internally dispatches `/gh-feedback-work` each tick and performs the merge) rather than the usual one-shot "hand off and report." This is one hand-off whose lifecycle lives in the sub-skill — not the router accumulating state across calls.
 
 **Propagate the authorization signal.** When the user's instruction (the `/gh` args or the message that invoked the router) explicitly directed the sub-skill's terminal action — post the issue, open the PR — carry that signal into the handoff so the sub-skill does not re-ask. A sub-skill's confirmation gate (e.g. `gh-issue-create` Phase 4, `gh-issue-work` Phase 8b) exists to confirm an action the user has NOT yet authorized; an explicit instruction routed through `/gh` already authorizes it. Conversely, when you reached the sub-skill by *inferring* a concrete ask from conversation (no explicit post/PR instruction), say so in the handoff — the gate stays live. Never strip a gate the user didn't waive; never re-raise one they did.
 

--- a/plugins/detritus/commands/babysit.md
+++ b/plugins/detritus/commands/babysit.md
@@ -5,4 +5,4 @@ argument-hint: "[pr] [interval]"
 
 The user invoked this command with: $ARGUMENTS
 
-Call the detritus MCP tool `kb_get` with `name="flows/github/gh-merge-loop"` and follow the returned guidance.
+Call the detritus MCP tool `kb_get` with `name="flows/github/babysit"` and follow the returned guidance.


### PR DESCRIPTION
## Summary
Renames the watch-until-merge PR-loop skill **`/gh-merge-loop` → `/babysit`**. Pure rename — behavior is unchanged.

## Changes
- `docs/flows/github/gh-merge-loop.md` → `docs/flows/github/babysit.md` (alias `gh-merge-loop` → `babysit`), doc retitled `# /babysit — Watch a PR Until Merged`.
- Triggers: dropped `gh-merge-loop`, added `babysit` / `babysit pr` / `babysit this pr`; the descriptive triggers (`watch pr`, `merge when approved`, `keep checking the pr`, …) are unchanged.
- `/gh` router (`gh.md`): updated the `related` entry, the open-PR watch-to-merge routing row, and the loop-variant note to point at `babysit`.
- Plugin shim regenerated (`gh-merge-loop.md` → `babysit.md`); README command table regenerated.

## Test plan
- [x] `go test ./...` green — alias-uniqueness, plugin-command drift, README drift, and doc-reference-resolution tests all pass.
- [x] Repo-wide grep confirms zero lingering `gh-merge-loop` references.
- [x] `data.gob` is a gitignored build artifact (generated by `go generate` in the release flow), so it is intentionally not committed.

## Note
On next `detritus --setup`/`--update`, the stale-skill prune removes the old installed `gh-merge-loop` skill and installs `babysit`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
