### PR TITLE
docs(readme): refresh stale intro + kb-only dirs to match the current product

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
 # detritus
 
-Detritus is an MCP knowledge base for AI coding assistants. It gives the
-assistant reusable guidance for planning, testing, GitHub work, project todos,
-and codebase exploration.
+Detritus is an MCP server for AI coding assistants. It exposes a curated
+knowledge base of engineering doctrine (`kb_*` tools), live codebase exploration
+(`code_*`), and verified cross-project learned memory (`skill_*`) — and layers
+on slash commands that share one delivery pipeline: plan, build,
+review-with-rework, deliver. Those commands run either in your session (`/plan`,
+`/smith`, `/forge`, `/janitor`, `/gh-*`, `/todo`, …) or hand off to the
+out-of-process **candyland sidecar** for multi-agent, dashboard-observable
+delivery (`/candyland`, `/quest`, `/campaign`, `/adventure`). No flow merges on
+its own — the human merge stays the gate.
 
 ## Install
 
@@ -26,8 +32,9 @@ tool yourself. Manual install details for an assistant or maintainer live in
 
 Use Detritus by command name. This table is generated from `docs/flows/` (run
 `detritus --readme`); the folder a doc lives in is its category. Internal
-building blocks (`docs/core/`) and agent roles (`docs/roles/`) are kb_get-only
-and intentionally absent — they are not commands.
+building blocks (`docs/core/`), agent roles (`docs/roles/`), and reference
+material (`docs/ooo/`, `docs/patterns/`) are kb_get-only and intentionally
+absent — they are not commands.
 
 <!-- COMMANDS:START -->
 


### PR DESCRIPTION
## Summary
Refreshes the stale hand-written prose in the README. The command table is auto-generated and already current — this touches only the intro and the Commands note, which had drifted behind the product.

## What was stale (audited against the repo)
- **Intro** described detritus as a passive *"MCP knowledge base … reusable guidance for planning, testing, GitHub work, project todos, and codebase exploration."* That omits the half of the product that actually **builds code and opens PRs**: the autonomous delivery flows that share one `plan → build → review-with-rework → deliver` pipeline (`docs/core/flows.md`), the in-session vs out-of-process **candyland sidecar** split (`docs/core/sidecar.md`, `coordination.md`), the **learned-memory** `skill_*` tools (`internal/memory/tools.go`), and the *no flow merges on its own — the human merge is the gate* invariant.
- **Commands note** listed only `docs/core/` and `docs/roles/` as the kb_get-only dirs absent from the table, but the table is generated solely from `docs/flows/` (`readme.go`), so `docs/ooo/` and `docs/patterns/` are equally kb-only.

## Changes
- Rewrote the intro to accurately frame the product: names all three MCP tool families (`kb_*` / `code_*` / `skill_*`), the shared delivery pipeline, and the in-session vs sidecar execution substrates.
- Completed the kb-only-dirs list (`docs/core/`, `docs/roles/`, `docs/ooo/`, `docs/patterns/`).
- Install section left as-is — verified still accurate for its audience.

## Test plan
- [x] Doc-drift tests green — `TestReadmeCommandsMatchFlows`, `TestPluginCommandsMatchFlows`, `TestPluginDocReferencesResolve`, `TestAliasForDocNoCollisions`, `TestGeneratedArtifactsAreTracked` all pass (prose edits are outside the `COMMANDS` markers; the generated table is unchanged).
- [x] Findings evidence-cited against the actual repo (flows.md, sidecar.md, coordination.md, main.go, internal/memory, readme.go) via a fresh read-only audit.

## Not a regression here
`TestMCPServer` / `TestBuildMCPServer` fail in my local WSL environment (subprocess-over-stdio spawn against a `/mnt/c` checkout) — but they fail identically on clean `main` with this change stashed, so they are pre-existing/environmental and unrelated to a README prose edit.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
