### PR TITLE
docs: launcher with no explicit target must ask, not launch on IDE state

### DIFF
--- a/docs/core/sidecar.md
+++ b/docs/core/sidecar.md
@@ -71,6 +71,10 @@ The sidecar **never merges** — merge is irreversible and gated on a human revi
 
 Before handing off, print: the **id**, the **dashboard URL**, the **deliver mode**, a one-line **what this will do**, and **both ports**.
 
+## No input is not an input — never launch on ambient context
+
+Every launcher requires an **explicit target**: a plan file/slug, a PR/issue reference, or a described objective present in the conversation. When the invocation carries **none** — a bare `/candyland` / `/quest` / `/adventure` / `/campaign` with no argument and nothing in the conversation naming the work — **ask which target; do not infer one.** Ambient IDE state (the currently-open editor file, a text selection) is flagged "may or may not be related" and is **never** a launch argument. A launcher spawns a branching, out-of-process agent tree that opens PRs; inferring its target from an open file is an unrequested launch, and stopping it after the fact still burns the spawn. This is the launch-side counterpart to `core/build`'s converge-don't-spray — the cheapest wrong PR is the one never launched.
+
 ## PR-link intake mirrors /gh
 
 `flows/github/gh` Phase 1 is the ONE canonical classifier; the launchers implement its **outcome** in Go against freshly-fetched state (`gh api`) whenever the input references a PR/issue:

--- a/docs/flows/build/candyland.md
+++ b/docs/flows/build/candyland.md
@@ -30,6 +30,7 @@ related:
 - **A settled `.plan/<slug>.md`** (or its slug) → launch directly.
 - **A PR/issue link or `#N`** → classify per the gh-mirror table (`core/sidecar` → *PR-link intake mirrors /gh*); the classification decides `deliver`/`targetPr`. A feedback/review outcome works that PR's head branch and opens no new PR.
 - **A vague/high-level description** → run the `dream` intake (`core/dream`) in-session first to settle a `.plan/<slug>.md`, then launch. `/candyland` never invents the plan.
+- **No input at all** (no argument AND nothing in the conversation naming what to build) → **ask which plan; never infer the target from ambient IDE state** (an open editor file, a selection) — see `core/sidecar` → *No input is not an input — never launch on ambient context*.
 
 ## Steps
 


### PR DESCRIPTION
## Summary
Closes #137 — documents that a sidecar launcher (/candyland, /quest, /adventure, /campaign) invoked with no explicit target must ask which target, rather than inferring one from whatever file happens to be open in the editor.

- Adds a "No input is not an input" rule to the shared sidecar doctrine: with no argument and nothing in the conversation naming the work, ask — ambient IDE state (open file, selection) is never a launch argument.
- Adds the matching no-input case to the /candyland intake guidance.

## Motivation
A launcher spawns a branching, out-of-process agent tree that opens pull requests. Inferring its target from ambient editor context can kick off expensive, unrequested work, and stopping it after the fact still burns the spawn. This makes the launch intentional.

## Test plan
- [ ] The doctrine states a no-target launcher must ask and that IDE state is not a launch argument.
- [ ] The /candyland intake list covers the no-input case and points to the shared rule.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)